### PR TITLE
replace addImport with ensureImports

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -22,7 +22,7 @@ module.exports = {
     const imports = getPackageImports(context, '@patternfly/react-core')
       .filter(specifier => specifier.imported.name === 'YOURCOMPONENTNAME');
       
-    return !imports ? {} : {
+    return imports.length == 0 ? {} : {
       JSXOpeningElement(node) {
         if (imports.map(imp => imp.local.name).includes(node.name.name)) {
           const attribute = node.attributes.find(node => node.name.name === 'variant');

--- a/packages/eslint-plugin-pf-codemods/lib/rules/alert-new-action.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/alert-new-action.js
@@ -6,7 +6,7 @@ module.exports = {
     const imports = getPackageImports(context, '@patternfly/react-core')
       .filter(specifier => specifier.imported.name === 'Alert');
       
-    return !imports ? {} : {
+    return imports.length === 0 ? {} : {
       JSXOpeningElement(node) {
         if (imports.map(imp => imp.local.name).includes(node.name.name)) {
           const attribute = node.attributes.find(node => node.name.name === 'action');

--- a/packages/eslint-plugin-pf-codemods/lib/rules/background-image-src-enum.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/background-image-src-enum.js
@@ -6,7 +6,7 @@ module.exports = {
     const imports = getPackageImports(context, '@patternfly/react-core')
       .filter(specifier => specifier.imported.name === 'BackgroundImageSrc');
       
-    return !imports ? {} : {
+    return imports.length == 0 ? {} : {
       Property(node) {
         if (node.key.object && imports.map(imp => imp.local.name).includes(node.key.object.name)) {
           const size = node.key.property.name;

--- a/packages/eslint-plugin-pf-codemods/lib/rules/card-rename-components.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/card-rename-components.js
@@ -1,4 +1,4 @@
-const { getPackageImports } = require('../helpers');
+const { getPackageImports, ensureImports } = require('../helpers');
 
 const renames = {
   'CardHeader': 'CardTitle',
@@ -12,7 +12,10 @@ module.exports = {
     const imports = getPackageImports(context, '@patternfly/react-core')
       .filter(specifier => Object.keys(renames).includes(specifier.imported.name));
     
-    return !imports ? {} : {
+    return imports.length === 0 ? {} : {
+      ImportDeclaration(node) {
+        ensureImports(context, node, '@patternfly/react-core', Object.values(renames));
+      },
       JSXIdentifier(node) {
         if (imports.map(imp => imp.local.name).includes(node.name)) {
           const alreadyFixed = node.parent.parent.openingElement && node.parent.parent.openingElement.attributes
@@ -20,11 +23,12 @@ module.exports = {
             .includes('data-codemods');
           if (!alreadyFixed) {
             const isOpeningCardHead = node.parent.type === 'JSXOpeningElement' && node.name === 'CardHead';
+            const replacement = `${renames[node.name]}${isOpeningCardHead ? ' data-codemods="true"' : ''}`;
             context.report({
               node,
               message: `${node.name} renamed to ${renames[node.name]}`,
               fix(fixer) {
-                return fixer.replaceText(node, `${renames[node.name]}${isOpeningCardHead ? ' data-codemods="true"' : ''}`);
+                return fixer.replaceText(node, replacement);
               }
             });
           }

--- a/packages/eslint-plugin-pf-codemods/lib/rules/chipgroup-remove-chipgrouptoolbaritem.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/chipgroup-remove-chipgrouptoolbaritem.js
@@ -8,9 +8,9 @@ module.exports = {
     const chipGroupImport = imports.find(imp => imp.imported.name === 'ChipGroup');
     const chipGroupToolbarItemImport = imports.find(imp => imp.imported.name === 'ChipGroupToolbarItem');
 
-    return !chipGroupImport ? {} : {
+    return !chipGroupImport || !chipGroupToolbarItemImport ? {} : {
       JSXElement(node) {
-        if (chipGroupToolbarItemImport && chipGroupToolbarItemImport.local.name === node.openingElement.name.name) {
+        if (chipGroupToolbarItemImport.local.name === node.openingElement.name.name) {
           const hasSingleChipGroupParent = node.parent
             && node.parent.openingElement.name.name === chipGroupImport.local.name
             && node.parent.children.filter(child => child.type === 'JSXElement').length === 1;

--- a/packages/eslint-plugin-pf-codemods/lib/rules/dropdown-rename-icon.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/dropdown-rename-icon.js
@@ -8,7 +8,7 @@ module.exports = {
     const dropdownItemImport = imports.find(imp => imp.imported.name === 'DropdownItem');
     const dropdownItemIconImport = imports.find(imp => imp.imported.name === 'DropdownItemIcon');
   
-    return !imports ? {} : {
+    return imports.length === 0 ? {} : {
       JSXElement(node) {
         if (dropdownItemImport && dropdownItemImport.local.name === node.openingElement.name.name) {
           const dropdownIcons = node.children.filter(child =>

--- a/packages/eslint-plugin-pf-codemods/lib/rules/pagination-removed-variant.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/pagination-removed-variant.js
@@ -6,7 +6,7 @@ module.exports = {
     const imports = getPackageImports(context, '@patternfly/react-core')
       .filter(specifier => specifier.imported.name === 'Pagination');
       
-    return !imports ? {} : {
+    return imports.length === 0 ? {} : {
       JSXOpeningElement(node) {
         if (imports.map(imp => imp.local.name).includes(node.name.name)) {
           const attribute = node.attributes.find(node => node.name.name === 'variant');

--- a/packages/eslint-plugin-pf-codemods/lib/rules/tab-title-text.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/tab-title-text.js
@@ -1,4 +1,4 @@
-const { getPackageImports, addImport } = require('../helpers');
+const { getPackageImports, ensureImports } = require('../helpers');
 
 // https://github.com/patternfly/patternfly-react/pull/4146
 module.exports = {
@@ -6,7 +6,10 @@ module.exports = {
     const tabImport = getPackageImports(context, '@patternfly/react-core')
       .filter(specifier => specifier.imported.name === 'Tab');
     
-    return tabImport.length ? {
+    return tabImport.length === 0 ? {} : {
+      ImportDeclaration(node) {
+        ensureImports(context, node, '@patternfly/react-core', ['TabTitleText']);
+      },
       JSXOpeningElement(node) {
         if (tabImport.map(imp => imp.local.name).includes(node.name.name)) {
           const attribute = node.attributes.find(node => node.name.name === 'title');
@@ -42,15 +45,13 @@ module.exports = {
                 node,
                 message: `title needs to be wrapped with the TabTitleText and/or TabTitleIcon component`,
                 fix(fixer) {
-                  return replacement(fixer).concat(
-                    addImport(context, fixer, '@patternfly/react-core', 'Tab', 'TabTitleText')
-                  );
+                  return replacement(fixer)
                 }
               });
             }
           }
         }
       }
-    } : {};
+    };
   }
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/title-require-heading-level.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/title-require-heading-level.js
@@ -6,7 +6,7 @@ module.exports = {
     const titleImports = getPackageImports(context, '@patternfly/react-core')
       .filter(specifier => specifier.imported.name === 'Title');
 
-    return !titleImports ? {} : {
+    return titleImports.length === 0 ? {} : {
       JSXOpeningElement(node) {
         if (titleImports.map(imp => imp.local.name).includes(node.name.name)) {
           if (!node.attributes.map(node => node.name.name).includes('headingLevel')) {

--- a/packages/eslint-plugin-pf-codemods/lib/rules/title-size.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/title-size.js
@@ -11,7 +11,7 @@ module.exports = {
     const titleImports = getPackageImports(context, '@patternfly/react-core')
       .filter(specifier => specifier.imported.name == 'Title');
       
-    return !titleImports ? {} : {
+    return titleImports.length === 0 ? {} : {
       JSXOpeningElement(node) {
         if (titleImports.map(imp => imp.local.name).includes(node.name.name)) {
           const sizeAttribute = node.attributes.find(n => n.name.name === 'size');

--- a/packages/eslint-plugin-pf-codemods/lib/rules/wizard-remove-props.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/wizard-remove-props.js
@@ -14,7 +14,7 @@ module.exports = {
     const imports = getPackageImports(context, '@patternfly/react-core')
       .filter(specifier => specifier.imported.name === 'Wizard');
       
-    return !imports ? {} : {
+    return imports.length === 0 ? {} : {
       JSXOpeningElement(node) {
         if (imports.map(imp => imp.local.name).includes(node.name.name)) {
           node.attributes

--- a/packages/eslint-plugin-pf-codemods/test/rules/card-rename-components.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/card-rename-components.js
@@ -36,7 +36,7 @@ ruleTester.run("card-rename-components", rule, {
     Title
   </CardHeader>
 </Card>`,
-      output: `import { Card, CardHead, CardHeadMain, CardHeader } from '@patternfly/react-core';
+      output: `import { Card, CardHead, CardHeadMain, CardHeader, CardTitle, CardHeaderMain } from '@patternfly/react-core';
 <Card>
   <CardHeader data-codemods="true">
     <CardHeaderMain>Header</CardHeaderMain>
@@ -46,6 +46,10 @@ ruleTester.run("card-rename-components", rule, {
   </CardTitle>
 </Card>`,
       errors: [
+        {
+          message: 'add missing imports CardTitle, CardHeaderMain from @patternfly/react-core',
+          type: 'ImportDeclaration'
+        },
         {
           message: 'CardHead renamed to CardHeader',
           type: 'JSXIdentifier'
@@ -75,9 +79,13 @@ ruleTester.run("card-rename-components", rule, {
     {
       code:   `import { Card, CardHead, CardHeadMain, CardHeader } from '@patternfly/react-core';
 <CardHead><CardHeadMain>Main</CardHeadMain></CardHead>`,
-      output: `import { Card, CardHead, CardHeadMain, CardHeader } from '@patternfly/react-core';
+      output: `import { Card, CardHead, CardHeadMain, CardHeader, CardTitle, CardHeaderMain } from '@patternfly/react-core';
 <CardHeader data-codemods="true"><CardHeaderMain>Main</CardHeaderMain></CardHeader>`,
       errors: [
+        {
+          message: 'add missing imports CardTitle, CardHeaderMain from @patternfly/react-core',
+          type: 'ImportDeclaration'
+        },
         {
           message: 'CardHead renamed to CardHeader',
           type: 'JSXIdentifier'

--- a/packages/eslint-plugin-pf-codemods/test/rules/tab-title-text.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/tab-title-text.js
@@ -13,12 +13,26 @@ ruleTester.run("tab-title-text", rule, {
   ],
   invalid: [
     {
-      code:   `import { Tab } from '@patternfly/react-core'; <Tab title="Title">Content</Tab>`,
-      output: `import { Tab, TabTitleText } from '@patternfly/react-core'; <Tab title={<TabTitleText>Title</TabTitleText>}>Content</Tab>`,
-      errors: [{
-        message: `title needs to be wrapped with the TabTitleText and/or TabTitleIcon component`,
-        type: "JSXOpeningElement",
-      }]
+      code:   `import { Tab } from '@patternfly/react-core';
+<Tab title="Title">Content</Tab>;
+<Tab title="Title">Content</Tab>;`,
+      output: `import { Tab, TabTitleText } from '@patternfly/react-core';
+<Tab title={<TabTitleText>Title</TabTitleText>}>Content</Tab>;
+<Tab title={<TabTitleText>Title</TabTitleText>}>Content</Tab>;`,
+      errors: [
+        {
+          message: 'add missing imports TabTitleText from @patternfly/react-core',
+          type: "ImportDeclaration"
+        },
+        {
+          message: `title needs to be wrapped with the TabTitleText and/or TabTitleIcon component`,
+          type: "JSXOpeningElement",
+        },
+        {
+          message: `title needs to be wrapped with the TabTitleText and/or TabTitleIcon component`,
+          type: "JSXOpeningElement",
+        }
+      ]
     },
   ]
 });


### PR DESCRIPTION
addImport couldn't work with `JSXIdentifier`s and had problems with the following code (it would not fix the second `<Tab>`):
```js
import { Tab } from '@patternfly/react-core';
<Tab title="Title">Content</Tab>;
<Tab title="Title">Content</Tab>;
```

This PR adds `ensureImports` which can run independently of other fixes (no state) and will run at the same time as them.