### PR TITLE
Chore/24 table removed transforms

### DIFF
--- a/packages/eslint-plugin-pf-codemods/index.js
+++ b/packages/eslint-plugin-pf-codemods/index.js
@@ -31,6 +31,7 @@ const rules = {
   "label-remove-isCompact": require('./lib/rules/label-remove-isCompact'),
   "rename-noPadding": require('./lib/rules/rename-noPadding'),
   "tab-title-text": require('./lib/rules/tab-title-text'),
+  "table-removed-transforms": require('./lib/rules/table-removed-transforms'),
 };
 
 module.exports = {

--- a/packages/eslint-plugin-pf-codemods/lib/rules/table-removed-transforms.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/table-removed-transforms.js
@@ -1,0 +1,29 @@
+const { getPackageImports } = require('../helpers');
+
+// https://github.com/patternfly/patternfly-react/pull/YOURNUMBERHERE
+module.exports = {
+  create: function(context) {
+    const imports = getPackageImports(context, '@patternfly/react-table')
+      .filter(specifier => specifier.imported.name === 'cellWidth');
+    
+    return !imports ? {} : {
+      CallExpression(node) {
+        const maxNode = node.callee.name && 
+          node.callee.name === 'cellWidth' &&
+          node.arguments.find(arg => arg.value === 'max');
+        if (!maxNode) {
+          return;
+        }
+        const nodeText = context.getSourceCode().getText(maxNode);
+        context.report({
+          node, 
+          message: `cellWidth(${nodeText}) has been replaced with cellWidth(100)`, 
+          fix(fixer) {
+            return fixer.replaceText(maxNode, '100');
+          }
+        });
+      }
+    }
+  }
+};
+

--- a/packages/eslint-plugin-pf-codemods/lib/rules/table-removed-transforms.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/table-removed-transforms.js
@@ -1,6 +1,6 @@
 const { getPackageImports } = require('../helpers');
 
-// https://github.com/patternfly/patternfly-react/pull/YOURNUMBERHERE
+// https://github.com/patternfly/patternfly-react/pull/4170
 module.exports = {
   create: function(context) {
     const imports = getPackageImports(context, '@patternfly/react-table')

--- a/packages/eslint-plugin-pf-codemods/test/rules/table-removed-transforms.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/table-removed-transforms.js
@@ -4,16 +4,39 @@ const rule = require('../../lib/rules/table-removed-transforms');
 ruleTester.run("table-removed-transforms", rule, {
   valid: [
     {
-      code: `VALID_CODE_HERE`,
+      code: `
+        import { Table, TableHeader, TableBody, cellWidth } from '@patternfly/react-table';
+        <Table rows={['Row 1']} cells={[{
+          title: 'Last Commit',
+          transforms: [cellWidth(100)]
+        }]}>
+          <TableHeader />
+          <TableBody />
+        </Table>
+      `,
     }
   ],
   invalid: [
     {
-      code:   `import { } from '@patternfly/react-core';`,
-      output: `import { } from '@patternfly/react-core';`,
+      code: `import { Table, TableHeader, TableBody, cellWidth } from '@patternfly/react-table';
+        <Table rows={['Row 1']} cells={[{
+          title: 'Last Commit',
+          transforms: [cellWidth('max')]
+        }]}>
+          <TableHeader />
+          <TableBody />
+        </Table>`,
+      output: `import { Table, TableHeader, TableBody, cellWidth } from '@patternfly/react-table';
+      <Table rows={['Row 1']} cells={[{
+        title: 'Last Commit',
+        transforms: [cellWidth(100)]
+      }]}>
+        <TableHeader />
+        <TableBody />
+      </Table>`,
       errors: [{
-        message: `YOUR_MESSAGE_HERE`,
-        type: "JSXOpeningElement",
+        message: `cellWidth no longer takes 'max' as argument; replaced with cellWidth(100)`,
+        type: "CallExpression",
       }]
     },
   ]

--- a/packages/eslint-plugin-pf-codemods/test/rules/table-removed-transforms.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/table-removed-transforms.js
@@ -1,0 +1,20 @@
+const ruleTester = require('./ruletester');
+const rule = require('../../lib/rules/table-removed-transforms');
+
+ruleTester.run("table-removed-transforms", rule, {
+  valid: [
+    {
+      code: `VALID_CODE_HERE`,
+    }
+  ],
+  invalid: [
+    {
+      code:   `import { } from '@patternfly/react-core';`,
+      output: `import { } from '@patternfly/react-core';`,
+      errors: [{
+        message: `YOUR_MESSAGE_HERE`,
+        type: "JSXOpeningElement",
+      }]
+    },
+  ]
+});


### PR DESCRIPTION
Towards #24 

Created codemod to replace `cellWidth('max')` with `cellWidth(100)` in `Table` component.