### PR TITLE
Fix breakpointMods don't apply

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -47,7 +47,7 @@ fs.writeFileSync(path.join(
   'packages/eslint-plugin-pf-codemods/test/rules',
   `${newRuleName}.js`
 ),
-`const ruleTester = require('./ruletester');
+`const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/${newRuleName}');
 
 ruleTester.run("${newRuleName}", rule, {

--- a/packages/eslint-plugin-pf-codemods/lib/rules/refactor-breakpointmods.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/refactor-breakpointmods.js
@@ -80,11 +80,15 @@ module.exports = {
             const attribute = node.attributes.find(attr => attr.name && attr.name.name === 'breakpointMods');
             if (
               attribute &&
+              attribute.value &&
               attribute.value.type === 'JSXExpressionContainer' &&
               attribute.value.expression &&
-              attribute.value.expression.type === 'ArrayExpression'
+              (attribute.value.expression.type === 'ArrayExpression' || attribute.value.expression.type === 'TSAsExpression')
             ) {
-              const breakpointModsArr = attribute.value.expression.elements;
+              const breakpointModsArrNode = (attribute.value.expression.type === 'TSAsExpression')
+                ? attribute.value.expression.expression
+                : attribute.value.expression;
+              const breakpointModsArr = breakpointModsArrNode.elements;
               const newModifier = {};
               breakpointModsArr.forEach(breakpointModObj => {
                 if (breakpointModObj.type === 'ObjectExpression') {

--- a/packages/eslint-plugin-pf-codemods/test/rules/accordion-remove-noBoxShadow.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/accordion-remove-noBoxShadow.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/accordion-remove-noBoxShadow');
 
 ruleTester.run("accordion-remove-noBoxShadow", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/alert-new-action.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/alert-new-action.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/alert-new-action');
 
 ruleTester.run("alert-new-action", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/application-launcher-rename-dropdownItems.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/application-launcher-rename-dropdownItems.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/application-launcher-rename-dropdownItems');
 
 ruleTester.run("application-launcher-rename-dropdownItems", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/aria-props.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/aria-props.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/aria-props');
 
 ruleTester.run("aria-props", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/background-image-src-enum.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/background-image-src-enum.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/background-image-src-enum');
 
 ruleTester.run("background-image-src-enum", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/card-rename-components.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/card-rename-components.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/card-rename-components');
 
 ruleTester.run("card-rename-components", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/chipgroup-remove-chipbutton.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/chipgroup-remove-chipbutton.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/chipgroup-remove-chipbutton');
 
 ruleTester.run("chipgroup-remove-chipbutton", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/chipgroup-remove-chipgrouptoolbaritem.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/chipgroup-remove-chipgrouptoolbaritem.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/chipgroup-remove-chipgrouptoolbaritem');
 
 ruleTester.run("chipgroup-remove-chipgrouptoolbaritem", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/chipgroup-remove-props.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/chipgroup-remove-props.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/chipgroup-remove-props');
 
 ruleTester.run("chipgroup-remove-props", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/datatoolbar-rename-toolbar.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/datatoolbar-rename-toolbar.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/datatoolbar-rename-toolbar');
 
 ruleTester.run("datatoolbar-rename-toolbar", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/dropdown-rename-icon.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/dropdown-rename-icon.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/dropdown-rename-icon');
 
 ruleTester.run("dropdown-rename-icon", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/dropdown-toggle-rename-iconComponent.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/dropdown-toggle-rename-iconComponent.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/dropdown-toggle-rename-iconComponent');
 
 ruleTester.run("dropdown-toggle-rename-iconComponent", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/empty-state-icon-removed-props.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/empty-state-icon-removed-props.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/empty-state-icon-removed-props');
 
 ruleTester.run("empty-state-icon-removed-props", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/expandable-rename-expandablesection.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/expandable-rename-expandablesection.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/expandable-rename-expandablesection');
 
 ruleTester.run("expandable-rename-expandablesection", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/form-fix-isValid.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/form-fix-isValid.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/form-fix-isValid');
 
 ruleTester.run("form-fix-isValid", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/global-background-color.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/global-background-color.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/global-background-color');
 
 ruleTester.run("global-background-color", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/label-remove-isCompact.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/label-remove-isCompact.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/label-remove-isCompact');
 
 ruleTester.run("label-remove-isCompact", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/modal-remove-props.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/modal-remove-props.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/modal-remove-props');
 
 ruleTester.run("modal-remove-props", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/modal-variant.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/modal-variant.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/modal-variant');
 
 ruleTester.run("modal-variant", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/nav-list-variant.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/nav-list-variant.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/nav-list-variant');
 const navListName = "NavList"
 const variant = {

--- a/packages/eslint-plugin-pf-codemods/test/rules/no-experimental-imports.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/no-experimental-imports.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/no-experimental-imports');
 
 ruleTester.run("no-experimental-imports", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/page-header-move-avatar.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/page-header-move-avatar.js
@@ -1,4 +1,4 @@
-const ruleTester = require("./ruletester");
+const ruleTester = require('../ruletester');
 const rule = require("../../lib/rules/page-header-move-avatar");
 
 ruleTester.run("page-header-move-avatar", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/page-header-prop-rename.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/page-header-prop-rename.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/page-header-prop-rename');
 
 ruleTester.run("page-header-prop-rename", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/pagination-removed-variant.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/pagination-removed-variant.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/pagination-removed-variant');
 
 ruleTester.run("pagination-removed-variant", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/progress-remove-info-variant.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/progress-remove-info-variant.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/progress-remove-info-variant');
 
 ruleTester.run("progress-remove-info-variant", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/refactor-breakpointmods.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/refactor-breakpointmods.js
@@ -98,6 +98,16 @@ ruleTester.run("refactor-breakpointmods", rule, {
         }
       ]
     },
+    {
+      code: `import { Flex } from '@patternfly/react-core';
+        <Flex breakpointMods={[{ modifier: 'justify-content-space-between' }] as any}></Flex>`,
+      output: `import { Flex } from '@patternfly/react-core';
+        <Flex justifyContent={{"default": "justifyContentSpaceBetween" }} as any}></Flex>`,
+      errors: [ {
+        message: `Removed breakpointMods prop from Flex in favor of spacer, spaceItems, grow, shrink, flex, direction, alignItems, alignContent, alignSelf, align, justifyContent, display, fullWidth and flexWrap`,
+        type: "JSXOpeningElement",
+      }]
+    },
   ]
 });
 

--- a/packages/eslint-plugin-pf-codemods/test/rules/refactor-breakpointmods.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/refactor-breakpointmods.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/refactor-breakpointmods');
 
 ruleTester.run("refactor-breakpointmods", rule, {
@@ -102,7 +102,7 @@ ruleTester.run("refactor-breakpointmods", rule, {
       code: `import { Flex } from '@patternfly/react-core';
         <Flex breakpointMods={[{ modifier: 'justify-content-space-between' }] as any}></Flex>`,
       output: `import { Flex } from '@patternfly/react-core';
-        <Flex justifyContent={{"default": "justifyContentSpaceBetween" }}></Flex>`,
+        <Flex justifyContent={{"default":"justifyContentSpaceBetween"}} ></Flex>`,
       errors: [ {
         message: `Removed breakpointMods prop from Flex in favor of spacer, spaceItems, grow, shrink, flex, direction, alignItems, alignContent, alignSelf, align, justifyContent, display, fullWidth and flexWrap`,
         type: "JSXOpeningElement",

--- a/packages/eslint-plugin-pf-codemods/test/rules/refactor-breakpointmods.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/refactor-breakpointmods.js
@@ -102,7 +102,7 @@ ruleTester.run("refactor-breakpointmods", rule, {
       code: `import { Flex } from '@patternfly/react-core';
         <Flex breakpointMods={[{ modifier: 'justify-content-space-between' }] as any}></Flex>`,
       output: `import { Flex } from '@patternfly/react-core';
-        <Flex justifyContent={{"default": "justifyContentSpaceBetween" }} as any}></Flex>`,
+        <Flex justifyContent={{"default": "justifyContentSpaceBetween" }}></Flex>`,
       errors: [ {
         message: `Removed breakpointMods prop from Flex in favor of spacer, spaceItems, grow, shrink, flex, direction, alignItems, alignContent, alignSelf, align, justifyContent, display, fullWidth and flexWrap`,
         type: "JSXOpeningElement",

--- a/packages/eslint-plugin-pf-codemods/test/rules/remove-gutter-size.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/remove-gutter-size.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/remove-gutter-size');
 
 ruleTester.run("remove-gutter-size", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/remove-isPseudo-props.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/remove-isPseudo-props.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/remove-isPseudo-props');
 
 ruleTester.run("remove-isPseudo-props", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/remove-unused-imports.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/remove-unused-imports.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/remove-unused-imports');
 
 ruleTester.run("remove-unused-imports", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/rename-noPadding.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/rename-noPadding.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/rename-noPadding');
 
 ruleTester.run("rename-noPadding", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/rename-toolbar-components.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/rename-toolbar-components.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/rename-toolbar-components');
 
 ruleTester.run("rename-toolbar-components", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/ruletester.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/ruletester.js
@@ -1,9 +1,0 @@
-const { RuleTester } = require("eslint");
-
-module.exports = new RuleTester({ parserOptions: {
-  sourceType: 'module',
-  ecmaVersion: 2015,
-  ecmaFeatures: {
-    jsx: true
-  }
-}});

--- a/packages/eslint-plugin-pf-codemods/test/rules/select-rename-checkbox.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/select-rename-checkbox.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/select-rename-checkbox');
 
 ruleTester.run("select-rename-checkbox", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/select-rename-isExpanded.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/select-rename-isExpanded.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/select-rename-isExpanded');
 
 ruleTester.run("select-rename-isExpanded", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/skip-to-content-remove-component.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/skip-to-content-remove-component.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/skip-to-content-remove-component');
 
 ruleTester.run("skip-to-content-remove-component", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/tab-rename-variant.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/tab-rename-variant.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/tab-rename-variant');
 
 ruleTester.run("tab-rename-variant", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/tab-title-text.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/tab-title-text.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/tab-title-text');
 
 ruleTester.run("tab-title-text", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/table-removed-transforms.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/table-removed-transforms.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/table-removed-transforms');
 
 ruleTester.run("table-removed-transforms", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/title-require-heading-level.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/title-require-heading-level.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/title-require-heading-level');
 
 ruleTester.run("title-require-heading-level", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/title-size.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/title-size.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/title-size');
 
 ruleTester.run("title-size", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/wizard-remove-props.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/wizard-remove-props.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/wizard-remove-props');
 
 ruleTester.run("wizard-remove-props", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/wizard-rename-hasBodyPadding.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/wizard-rename-hasBodyPadding.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/wizard-rename-hasBodyPadding');
 
 ruleTester.run("wizard-rename-hasBodyPadding", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/rules/wizard-rename-text.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/wizard-rename-text.js
@@ -1,4 +1,4 @@
-const ruleTester = require('./ruletester');
+const ruleTester = require('../ruletester');
 const rule = require('../../lib/rules/wizard-rename-text');
 
 ruleTester.run("wizard-rename-text", rule, {

--- a/packages/eslint-plugin-pf-codemods/test/ruletester.js
+++ b/packages/eslint-plugin-pf-codemods/test/ruletester.js
@@ -1,0 +1,12 @@
+const { RuleTester } = require('eslint');
+
+module.exports = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015,
+    ecmaFeatures: {
+      jsx: true
+    }
+  }
+});

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -1,15 +1,15 @@
-import { Title, Title as MyTitle, TabTitleText, TabTitleIcon } from '@patternfly/react-core';
+import { Title, Title as MyTitle } from '@patternfly/react-core';
 
-export const Thing1 = () => <MyTitle headingLevel="h2" size="md">Title</MyTitle>;
-export const Thing2 = () => <Title headingLevel="h2" size="md">Title</Title>;
+export const Thing1 = () => <MyTitle size="md">Title</MyTitle>;
+export const Thing2 = () => <Title size="md">Title</Title>;
 
-import { List, ListVariant, TabTitleText, TabTitleIcon } from '@patternfly/react-core';
+import { List, ListVariant } from '@patternfly/react-core';
 
 export const MyList = (
   <List variant={ListVariant.plain} />
 )
 
-import { Button, ButtonVariant as MyButtonVaraitn, TabTitleText, TabTitleIcon } from '@patternfly/react-core';
+import { Button, ButtonVariant as MyButtonVaraitn } from '@patternfly/react-core';
 
 export const MyButton = (
   <Button variant={MyButtonVaraitn.plain} />
@@ -24,52 +24,52 @@ export const MyButtonWithCustomEnum = (
   <Button variant={MyPfEnums.plain} />
 )
 
-import { Tab  } from '@patternfly/react-core';
+import { Tab, TitleSize } from '@patternfly/react-core';
 const tabText = <TabTitleText>After</TabTitleText>;
 const TabTextComp = () => <TabTitleText>After</TabTitleText>;
-export const TestTab = <Tab title={<TabTitleText>hello</TabTitleText>}>Content</Tab>;
+export const TestTab = <Tab title="hello">Content</Tab>;
 export const TestTab2a = <Tab title={<TabTitleText>hello</TabTitleText>}>Content</Tab>;
 export const TestTab2b = <Tab title={<TabTitleIcon><UsersIcon /></TabTitleIcon>}>Content</Tab>;
-export const TestTab3 = <Tab title={<TabTitleText>hello</TabTitleText>}>Content</Tab>;
-export const TestTab3a = <Tab title={<TabTitleText>5</TabTitleText>}>Content</Tab>;
-export const TestTab4 = <Tab title={<TabTitleText>{tabText}</TabTitleText>}>Content</Tab>;
-export const TestTab5 = <Tab title={<TabTitleText><TabTextComp /></TabTitleText>}>Content</Tab>;
-export const TestTab6 = <Tab title={<div><TabTitleText>hello</TabTitleText></div>}>Content</Tab>;
+export const TestTab3 = <Tab title={'hello'}>Content</Tab>;
+export const TestTab3a = <Tab title={5}>Content</Tab>;
+export const TestTab4 = <Tab title={tabText}>Content</Tab>;
+export const TestTab5 = <Tab title={<TabTextComp />}>Content</Tab>;
+export const TestTab6 = <Tab title={<div>hello</div>}>Content</Tab>;
 
-export const TestTab7 = <Tab title={<TabTitleIcon><UsersIcon /></TabTitleIcon>}>Content</Tab>;
-export const TestTab8 = <Tab title={<><TabTitleIcon><UsersIcon /></TabTitleIcon><TabTitleText> Text</TabTitleText></>}>Content</Tab>;
+export const TestTab7 = <Tab title={<UsersIcon />}>Content</Tab>;
+export const TestTab8 = <Tab title={<><UsersIcon /> Text</>}>Content</Tab>;
 
 import { Table, cellWidth } from "@patternfly/react-table";
-export const TableA = <Table cells={[{ transforms: [cellWidth(100)] }]}></Table>;
+export const TableA = <Table cells={[{ transforms: [cellWidth('max')] }]}></Table>;
 
-import { Table, cellWidth  } from '@patternfly/react-table';
-export const TableB = <Table cells={[{ transforms: [ cellWidth(100)  ] }]}></Table>
-export const TableC = <Table cells={[{ transforms: [  ] }]}></Table>
+import { Table, cellWidth, cellHeightAuto } from '@patternfly/react-table';
+export const TableB = <Table cells={[{ transforms: [ cellWidth('max'), cellHeightAuto() ] }]}></Table>
+export const TableC = <Table cells={[{ transforms: [ cellHeightAuto() ] }]}></Table>
 
-import { Wizard, TabTitleText, TabTitleIcon } from '@patternfly/react-core'; 
+import { Wizard } from '@patternfly/react-core'; 
 // should change to hasNoBodyPadding
-export const WizA = <Wizard hasNoBodyPadding />
+export const WizA = <Wizard hasBodyPadding={ false } />
 // should remove the prop since hasNoBodyPadding defaults to false
-export const WizB = <Wizard  />
-export const WizC = <Wizard  />
+export const WizB = <Wizard hasBodyPadding />
+export const WizC = <Wizard hasBodyPadding={ true } />
 
-import { ExpandableSection } from '@patternfly/react-core';
-export const TestExpandable = <ExpandableSection toggleText="Show More" ></ExpandableSection>;
+import { Expandable } from '@patternfly/react-core';
+export const TestExpandable = <Expandable toggleText="Show More" ></Expandable>;
 
-import {  } from '@patternfly/react-core';
-export const TestChipButton = <Button></Button>;
+import { ChipButton } from '@patternfly/react-core';
+export const TestChipButton = <ChipButton></ChipButton>;
 
-import { Avatar, Page, PageHeader, PageHeaderTools, PageHeaderToolsGroup, PageHeaderToolsItem } from '@patternfly/react-core';
+import { Avatar, Page, PageHeader, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 <Page>
-  <PageHeader  headerTools={
-    <PageHeaderTools>
-      <PageHeaderToolsGroup>
-        <PageHeaderToolsItem></PageHeaderToolsItem>
-      </PageHeaderToolsGroup>
-    <Avatar /></PageHeaderTools>
+  <PageHeader avatar={<Avatar />} toolbar={
+    <Toolbar>
+      <ToolbarGroup>
+        <ToolbarItem></ToolbarItem>
+      </ToolbarGroup>
+    </Toolbar>
   }
   />
-</Page>
+</Page>;
 
-import { Flex, TabTitleText, TabTitleIcon } from '@patternfly/react-core';
-<Flex justifyContent={{"default":"justifyContentSpaceBetween"}} ></Flex>;
+import { Flex } from '@patternfly/react-core';
+<Flex breakpointMods={[{ modifier: 'justify-content-space-between' }] as any}></Flex>

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -1,15 +1,15 @@
-import { Title, Title as MyTitle } from '@patternfly/react-core';
+import { Title, Title as MyTitle, TabTitleText, TabTitleIcon } from '@patternfly/react-core';
 
-export const Thing1 = () => <MyTitle size="md">Title</MyTitle>;
-export const Thing2 = () => <Title size="md">Title</Title>;
+export const Thing1 = () => <MyTitle headingLevel="h2" size="md">Title</MyTitle>;
+export const Thing2 = () => <Title headingLevel="h2" size="md">Title</Title>;
 
-import { List, ListVariant } from '@patternfly/react-core';
+import { List, ListVariant, TabTitleText, TabTitleIcon } from '@patternfly/react-core';
 
 export const MyList = (
   <List variant={ListVariant.plain} />
 )
 
-import { Button, ButtonVariant as MyButtonVaraitn } from '@patternfly/react-core';
+import { Button, ButtonVariant as MyButtonVaraitn, TabTitleText, TabTitleIcon } from '@patternfly/react-core';
 
 export const MyButton = (
   <Button variant={MyButtonVaraitn.plain} />
@@ -24,49 +24,52 @@ export const MyButtonWithCustomEnum = (
   <Button variant={MyPfEnums.plain} />
 )
 
-import { Tab, TitleSize } from '@patternfly/react-core';
+import { Tab  } from '@patternfly/react-core';
 const tabText = <TabTitleText>After</TabTitleText>;
 const TabTextComp = () => <TabTitleText>After</TabTitleText>;
-export const TestTab = <Tab title="hello">Content</Tab>;
+export const TestTab = <Tab title={<TabTitleText>hello</TabTitleText>}>Content</Tab>;
 export const TestTab2a = <Tab title={<TabTitleText>hello</TabTitleText>}>Content</Tab>;
 export const TestTab2b = <Tab title={<TabTitleIcon><UsersIcon /></TabTitleIcon>}>Content</Tab>;
-export const TestTab3 = <Tab title={'hello'}>Content</Tab>;
-export const TestTab3a = <Tab title={5}>Content</Tab>;
-export const TestTab4 = <Tab title={tabText}>Content</Tab>;
-export const TestTab5 = <Tab title={<TabTextComp />}>Content</Tab>;
-export const TestTab6 = <Tab title={<div>hello</div>}>Content</Tab>;
+export const TestTab3 = <Tab title={<TabTitleText>hello</TabTitleText>}>Content</Tab>;
+export const TestTab3a = <Tab title={<TabTitleText>5</TabTitleText>}>Content</Tab>;
+export const TestTab4 = <Tab title={<TabTitleText>{tabText}</TabTitleText>}>Content</Tab>;
+export const TestTab5 = <Tab title={<TabTitleText><TabTextComp /></TabTitleText>}>Content</Tab>;
+export const TestTab6 = <Tab title={<div><TabTitleText>hello</TabTitleText></div>}>Content</Tab>;
 
-export const TestTab7 = <Tab title={<UsersIcon />}>Content</Tab>;
-export const TestTab8 = <Tab title={<><UsersIcon /> Text</>}>Content</Tab>;
+export const TestTab7 = <Tab title={<TabTitleIcon><UsersIcon /></TabTitleIcon>}>Content</Tab>;
+export const TestTab8 = <Tab title={<><TabTitleIcon><UsersIcon /></TabTitleIcon><TabTitleText> Text</TabTitleText></>}>Content</Tab>;
 
 import { Table, cellWidth } from "@patternfly/react-table";
-export const TableA = <Table cells={[{ transforms: [cellWidth('max')] }]}></Table>;
+export const TableA = <Table cells={[{ transforms: [cellWidth(100)] }]}></Table>;
 
-import { Table, cellWidth, cellHeightAuto } from '@patternfly/react-table';
-export const TableB = <Table cells={[{ transforms: [ cellWidth('max'), cellHeightAuto() ] }]}></Table>
-export const TableC = <Table cells={[{ transforms: [ cellHeightAuto() ] }]}></Table>
+import { Table, cellWidth  } from '@patternfly/react-table';
+export const TableB = <Table cells={[{ transforms: [ cellWidth(100)  ] }]}></Table>
+export const TableC = <Table cells={[{ transforms: [  ] }]}></Table>
 
-import { Wizard } from '@patternfly/react-core'; 
+import { Wizard, TabTitleText, TabTitleIcon } from '@patternfly/react-core'; 
 // should change to hasNoBodyPadding
-export const WizA = <Wizard hasBodyPadding={ false } />
+export const WizA = <Wizard hasNoBodyPadding />
 // should remove the prop since hasNoBodyPadding defaults to false
-export const WizB = <Wizard hasBodyPadding />
-export const WizC = <Wizard hasBodyPadding={ true } />
+export const WizB = <Wizard  />
+export const WizC = <Wizard  />
 
-import { Expandable } from '@patternfly/react-core';
-export const TestExpandable = <Expandable toggleText="Show More" ></Expandable>;
+import { ExpandableSection } from '@patternfly/react-core';
+export const TestExpandable = <ExpandableSection toggleText="Show More" ></ExpandableSection>;
 
-import { ChipButton } from '@patternfly/react-core';
-export const TestChipButton = <ChipButton></ChipButton>;
+import {  } from '@patternfly/react-core';
+export const TestChipButton = <Button></Button>;
 
-import { Avatar, Page, PageHeader, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import { Avatar, Page, PageHeader, PageHeaderTools, PageHeaderToolsGroup, PageHeaderToolsItem } from '@patternfly/react-core';
 <Page>
-  <PageHeader avatar={<Avatar />} toolbar={
-    <Toolbar>
-      <ToolbarGroup>
-        <ToolbarItem></ToolbarItem>
-      </ToolbarGroup>
-    </Toolbar>
+  <PageHeader  headerTools={
+    <PageHeaderTools>
+      <PageHeaderToolsGroup>
+        <PageHeaderToolsItem></PageHeaderToolsItem>
+      </PageHeaderToolsGroup>
+    <Avatar /></PageHeaderTools>
   }
   />
 </Page>
+
+import { Flex, TabTitleText, TabTitleIcon } from '@patternfly/react-core';
+<Flex justifyContent={{"default":"justifyContentSpaceBetween"}} ></Flex>;


### PR DESCRIPTION
Towards #78 

This PR updated the breakpointMods codemod in the case of typing the breakpointMods array:
`<Flex breakpointMods={[{ modifier: 'justify-content-space-between' }] as any}></Flex>`