### PR TITLE
Add data-codemods attribute on rename

### DIFF
--- a/packages/eslint-plugin-pf-codemods/index.js
+++ b/packages/eslint-plugin-pf-codemods/index.js
@@ -19,8 +19,6 @@ const rules = {
   "alert-new-action": require('./lib/rules/alert-new-action'),
   "card-rename-components": require('./lib/rules/card-rename-components'),
   "chipgroup-remove-props": require('./lib/rules/chipgroup-remove-props'),
-  "chipgroup-remove-props": require('./lib/rules/chipgroup-remove-props'),
-  "chipgroup-remove-chipbutton": require('./lib/rules/chipgroup-remove-chipbutton'),
   "chipgroup-remove-chipbutton": require('./lib/rules/chipgroup-remove-chipbutton'),
   "chipgroup-remove-chipgrouptoolbaritem": require('./lib/rules/chipgroup-remove-chipgrouptoolbaritem'),
   "dropdown-rename-icon": require('./lib/rules/dropdown-rename-icon'),

--- a/packages/eslint-plugin-pf-codemods/test/rules/chipgroup-remove-chipbutton.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/chipgroup-remove-chipbutton.js
@@ -13,11 +13,11 @@ ruleTester.run("chipgroup-remove-chipbutton", rule, {
   invalid: [
     {
       code:   `import { ChipButton } from '@patternfly/react-core'; <ChipButton>button</ChipButton>`,
-      output: `import { Button } from '@patternfly/react-core'; <Button>button</Button>`,
+      output: `import { ChipButton, Button } from '@patternfly/react-core'; <Button>button</Button>`,
       errors: [
         {
-          message: `ChipButton has been replaced with Button`,
-          type: "ImportSpecifier",
+          message: `add missing imports Button from @patternfly/react-core`,
+          type: "ImportDeclaration",
         },
         {
           message: `ChipButton has been replaced with Button`,

--- a/packages/eslint-plugin-pf-codemods/test/rules/expandable-rename-expandablesection.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/expandable-rename-expandablesection.js
@@ -14,22 +14,14 @@ ruleTester.run("expandable-rename-expandablesection", rule, {
   ],
   invalid: [
     {
-      code:   `import { Expandable } from '@patternfly/react-core';`,
-      output: `import { ExpandableSection } from '@patternfly/react-core';`,
-      errors: [{
-        message: `Expandable has been replaced with ExpandableSection`,
-        type: "ImportSpecifier",
-      }]
-    },
-    {
       code:   `import { Expandable } from '@patternfly/react-core';
         <Expandable toggleText="Show More"></Expandable>`,
-      output: `import { ExpandableSection } from '@patternfly/react-core';
+      output: `import { Expandable, ExpandableSection } from '@patternfly/react-core';
         <ExpandableSection toggleText="Show More"></ExpandableSection>`,
       errors: [
         {
-          message: `Expandable has been replaced with ExpandableSection`,
-          type: "ImportSpecifier",
+          message: `add missing imports ExpandableSection from @patternfly/react-core`,
+          type: "ImportDeclaration",
         },
         {
           message: 'Expandable has been replaced with ExpandableSection',

--- a/packages/eslint-plugin-pf-codemods/test/rules/rename-toolbar-components.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/rename-toolbar-components.js
@@ -39,7 +39,7 @@ ruleTester.run("rename-toolbar-components", rule, {
       </Page>
       `,
       output: `
-      import { Page, PageHeader, PageHeaderTools, PageHeaderToolsGroup, PageHeaderToolsItem } from '@patternfly/react-core';
+      import { Page, PageHeader, Toolbar, ToolbarGroup, ToolbarItem, PageHeaderTools, PageHeaderToolsGroup, PageHeaderToolsItem } from '@patternfly/react-core';
       <Page>
         <PageHeader toolbar={
           <PageHeaderTools>
@@ -53,15 +53,7 @@ ruleTester.run("rename-toolbar-components", rule, {
       `,
       errors: [
         {
-          message: `add missing imports PageHeaderTools from @patternfly/react-core`,
-          type: "ImportDeclaration",
-        },
-        {
-          message: `add missing imports PageHeaderToolsGroup from @patternfly/react-core`,
-          type: "ImportDeclaration",
-        },
-        {
-          message: `add missing imports PageHeaderToolsItem from @patternfly/react-core`,
+          message: `add missing imports PageHeaderTools, PageHeaderToolsGroup, PageHeaderToolsItem from @patternfly/react-core`,
           type: "ImportDeclaration",
         },
         {

--- a/packages/eslint-plugin-pf-codemods/test/rules/rename-toolbar-components.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/rename-toolbar-components.js
@@ -53,16 +53,16 @@ ruleTester.run("rename-toolbar-components", rule, {
       `,
       errors: [
         {
-          message: `Toolbar has been replaced with PageHeaderTools`,
-          type: "ImportSpecifier",
+          message: `add missing imports PageHeaderTools from @patternfly/react-core`,
+          type: "ImportDeclaration",
         },
         {
-          message: `ToolbarGroup has been replaced with PageHeaderToolsGroup`,
-          type: "ImportSpecifier",
+          message: `add missing imports PageHeaderToolsGroup from @patternfly/react-core`,
+          type: "ImportDeclaration",
         },
         {
-          message: `ToolbarItem has been replaced with PageHeaderToolsItem`,
-          type: "ImportSpecifier",
+          message: `add missing imports PageHeaderToolsItem from @patternfly/react-core`,
+          type: "ImportDeclaration",
         },
         {
           message: `Toolbar has been replaced with PageHeaderTools`,

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -59,17 +59,20 @@ export const TestExpandable = <Expandable toggleText="Show More" ></Expandable>;
 import { ChipButton } from '@patternfly/react-core';
 export const TestChipButton = <ChipButton></ChipButton>;
 
-import { Avatar, Page, PageHeader, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
-<Page>
-  <PageHeader avatar={<Avatar />} toolbar={
-    <Toolbar>
-      <ToolbarGroup>
-        <ToolbarItem></ToolbarItem>
-      </ToolbarGroup>
-    </Toolbar>
-  }
-  />
-</Page>;
+// import { Avatar, Page, PageHeader, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+// <Page>
+//   <PageHeader avatar={<Avatar />} toolbar={
+//     <Toolbar>
+//       <ToolbarGroup>
+//         <ToolbarItem></ToolbarItem>
+//       </ToolbarGroup>
+//     </Toolbar>
+//   }
+//   />
+// </Page>;
 
 import { Flex } from '@patternfly/react-core';
 <Flex breakpointMods={[{ modifier: 'justify-content-space-between' }] as any}></Flex>
+
+import { DataToolbar } from '@patternfly/react-core';
+<DataToolbar></DataToolbar>


### PR DESCRIPTION
Closes #82 

This PR adds data-codemods attributes to renamed components that would potentially be renamed a second time, and leaves removing the previous names' imports to `no-unused-imports` rule (#90)