### PR TITLE
added react-icons-remove-icon rules & tests

### DIFF
--- a/packages/eslint-plugin-pf-codemods/index.js
+++ b/packages/eslint-plugin-pf-codemods/index.js
@@ -43,6 +43,7 @@ const rules = {
   "datatoolbar-rename-toolbar": require('./lib/rules/datatoolbar-rename-toolbar'),
   "chartVoronoiContainer-remove-allowTooltip": require('./lib/rules/chartVoronoiContainer-remove-allowTooltip'),
   "chart-remove-allowZoom": require('./lib/rules/chartVoronoiContainer-remove-allowTooltip'),
+  "react-icons-remove-icon": require('./lib/rules/react-icons-remove-icon'),
 };
 
 module.exports = {

--- a/packages/eslint-plugin-pf-codemods/lib/rules/react-icons-remove-icon.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/react-icons-remove-icon.js
@@ -8,28 +8,30 @@ module.exports = {
 
     const fortAwesomeImports = getPackageImports(context, '@fortawesome/free-regular-svg-icons');
     const importStatement = `import { fontAwesomeLogoFull } from '@fortawesome/free-regular-svg-icons';`
-    if (fortAwesomeImports.length === 0) {
-      const lastImportNode = context.getSourceCode().ast.body
-        .filter(node => node.type === 'ImportDeclaration')
-        .pop();
-      context.report({
-        node: lastImportNode,
-        message: `add missing ${importStatement}`,
-        fix(fixer) {
-          return fixer.insertTextAfter(lastImportNode, '\n' + importStatement)
-        }
-      });
-    } else {
-      const hasFontAwesomeLogoFullImport = fortAwesomeImports.find(imp => imp.imported.name === 'fontAwesomeLogoFull');
-      if (!hasFontAwesomeLogoFullImport) {
-        const lastImportedIcon = fortAwesomeImports[fortAwesomeImports.length - 1];
+    if (imports.length) {
+      if (fortAwesomeImports.length === 0) {
+        const lastImportNode = context.getSourceCode().ast.body
+          .filter(node => node.type === 'ImportDeclaration')
+          .pop();
         context.report({
-          node: lastImportedIcon.parent,
+          node: lastImportNode,
           message: `add missing ${importStatement}`,
           fix(fixer) {
-            return fixer.insertTextAfter(lastImportedIcon, ', fontAwesomeLogoFull');
+            return fixer.insertTextAfter(lastImportNode, '\n' + importStatement)
           }
         });
+      } else {
+        const hasFontAwesomeLogoFullImport = fortAwesomeImports.find(imp => imp.imported.name === 'fontAwesomeLogoFull');
+        if (!hasFontAwesomeLogoFullImport) {
+          const lastImportedIcon = fortAwesomeImports[fortAwesomeImports.length - 1];
+          context.report({
+            node: lastImportedIcon.parent,
+            message: `add missing ${importStatement}`,
+            fix(fixer) {
+              return fixer.insertTextAfter(lastImportedIcon, ', fontAwesomeLogoFull');
+            }
+          });
+        }
       }
     }
       

--- a/packages/eslint-plugin-pf-codemods/lib/rules/react-icons-remove-icon.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/react-icons-remove-icon.js
@@ -1,0 +1,67 @@
+const { getPackageImports } = require('../helpers');
+
+// https://github.com/patternfly/patternfly-react/pull/YOURNUMBERHERE
+module.exports = {
+  create: function(context) {
+    const imports = getPackageImports(context, '@patternfly/react-icons')
+      .filter(specifier => specifier.imported.name === 'OutlinedFontAwesomeLogoFullIcon');
+
+    const fortAwesomeImports = getPackageImports(context, '@fortawesome/free-regular-svg-icons');
+    const importStatement = `import { fontAwesomeLogoFull } from '@fortawesome/free-regular-svg-icons';`
+    if (fortAwesomeImports.length === 0) {
+      const lastImportNode = context.getSourceCode().ast.body
+        .filter(node => node.type === 'ImportDeclaration')
+        .pop();
+      context.report({
+        node: lastImportNode,
+        message: `add missing ${importStatement}`,
+        fix(fixer) {
+          return fixer.insertTextAfter(lastImportNode, '\n' + importStatement)
+        }
+      });
+    } else {
+      const hasFontAwesomeLogoFullImport = fortAwesomeImports.find(imp => imp.imported.name === 'fontAwesomeLogoFull');
+      if (!hasFontAwesomeLogoFullImport) {
+        const lastImportedIcon = fortAwesomeImports[fortAwesomeImports.length - 1];
+        context.report({
+          node: lastImportedIcon.parent,
+          message: `add missing ${importStatement}`,
+          fix(fixer) {
+            return fixer.insertTextAfter(lastImportedIcon, ', fontAwesomeLogoFull');
+          }
+        });
+      }
+    }
+      
+    return imports.length == 0 ? {} : {
+      ImportSpecifier(node) {
+        if (imports.map(imp => imp.local.name).includes(node.local.name)) {
+
+          const sourceCode = context.getSourceCode();
+          const previousToken = sourceCode.getTokenBefore(node);
+          const previousTokenText = sourceCode.getText(previousToken);
+          const lastNodeToken = sourceCode.getLastToken(node);
+          const nextToken = sourceCode.getTokenAfter(lastNodeToken);
+          const nextTokenText = sourceCode.getText(nextToken);
+          context.report({
+            node, 
+            message: `Removed OutlinedFontAwesomeLogoFullIcon. Import it from @FortAwesome instead.`, 
+            fix(fixer) {
+              const fixes = [
+                fixer.remove(node)
+              ];
+              if (nextTokenText === '}' && previousTokenText === ',') {
+                // it's the last item but has a preceding item, clean up previous comma
+                fixes.push(fixer.remove(previousToken));
+              }
+              if (nextTokenText === ',') {
+                fixes.push(fixer.remove(nextToken));
+              }
+              return fixes;
+            }
+          })
+        }
+      }
+    };
+  }
+};

--- a/packages/eslint-plugin-pf-codemods/test/rules/react-icons-remove-icon.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/react-icons-remove-icon.js
@@ -1,0 +1,53 @@
+const ruleTester = require('../ruletester');
+const rule = require('../../lib/rules/react-icons-remove-icon');
+
+ruleTester.run("react-icons-remove-icon", rule, {
+  valid: [
+    {
+      code: `import { fontAwesomeLogoFull } from '@fortawesome/free-regular-svg-icons';`,
+    }
+  ],
+  invalid: [
+    {
+      code:   `import { OutlinedFontAwesomeLogoFullIcon } from '@patternfly/react-icons';`,
+      output: `import {  } from '@patternfly/react-icons';
+import { fontAwesomeLogoFull } from '@fortawesome/free-regular-svg-icons';`,
+      errors: [
+        {
+          message: `add missing import { fontAwesomeLogoFull } from '@fortawesome/free-regular-svg-icons';`,
+          type: "ImportDeclaration",
+        },
+        {
+          message: `Removed OutlinedFontAwesomeLogoFullIcon. Import it from @FortAwesome instead.`,
+          type: "ImportSpecifier",
+        }
+      ]
+    },
+    {
+      code:   `import { OutlinedFontAwesomeLogoFullIcon } from '@patternfly/react-icons';
+import { fontAwesomeLogoFull } from '@fortawesome/free-regular-svg-icons';`,
+      output: `import {  } from '@patternfly/react-icons';
+import { fontAwesomeLogoFull } from '@fortawesome/free-regular-svg-icons';`,
+      errors: [{
+        message: `Removed OutlinedFontAwesomeLogoFullIcon. Import it from @FortAwesome instead.`,
+        type: "ImportSpecifier",
+      }]
+    },
+    {
+      code:   `import { OutlinedFontAwesomeLogoFullIcon } from '@patternfly/react-icons';
+import { anotherIcon } from '@fortawesome/free-regular-svg-icons';`,
+      output: `import {  } from '@patternfly/react-icons';
+import { anotherIcon, fontAwesomeLogoFull } from '@fortawesome/free-regular-svg-icons';`,
+      errors: [
+        {
+          message: `Removed OutlinedFontAwesomeLogoFullIcon. Import it from @FortAwesome instead.`,
+          type: "ImportSpecifier",
+        },
+        {
+          message: `add missing import { fontAwesomeLogoFull } from '@fortawesome/free-regular-svg-icons';`,
+          type: "ImportDeclaration",
+        }
+      ]
+    },
+  ]
+});


### PR DESCRIPTION
Closes #18 

- Checks for & removes import of `OutlinedFontAwesomeLogoFullIcon` from `@patternfly/react-icons`
- Checks for existing `@fortawesome/free-regular-svg-icons` imports & adds `fontAwesomeLogoFull` to it if needed, otherwise adds new import statement `import { fontAwesomeLogoFull } from '@fortawesome/free-regular-svg-icons';`