### PR TITLE
fix(title-size): check for sizeAttribute to be truthy before proceeding

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/rules/title-size.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/title-size.js
@@ -14,9 +14,8 @@ module.exports = {
     return titleImports.length === 0 ? {} : {
       JSXOpeningElement(node) {
         if (titleImports.map(imp => imp.local.name).includes(node.name.name)) {
-          const sizeAttribute = node.attributes.find(n => n.name && n.name.name === 'size');
-          const sizeValue = sizeAttribute.value.value;
-          if (sizeAttribute && !validSizes.includes(sizeValue)) {
+          const sizeAttribute = node.attributes.find(n => n.name && n.name.name === 'size');;
+          if (sizeAttribute && !validSizes.includes(sizeAttribute.value.value)) {
             const sizeValueString = context.getSourceCode().getText(sizeAttribute.value);
             const valueGuess = validSizes.find(val => sizeValueString.includes(val)) || 'md';
             context.report({

--- a/packages/eslint-plugin-pf-codemods/test/rules/title-size.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/title-size.js
@@ -13,6 +13,10 @@ ruleTester.run("title-size", rule, {
     {
       code: `import { Title } from '@patternfly/react-core'; <Title size="4xl" />`,
     },
+    {
+      // No size attribute
+      code: `import { Title } from '@patternfly/react-core'; <Title />`,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Closes #116 

Updated title-size to check that `sizeAttribute` exists before reading property on it