### PR TITLE
feat(Spinner): remove isSVG

### DIFF
--- a/packages/eslint-plugin-pf-codemods/index.js
+++ b/packages/eslint-plugin-pf-codemods/index.js
@@ -55,6 +55,7 @@ const rules = {
   "pagination-rename-props": require('./lib/rules/v5/pagination-rename-props'),
   "resizeObserver-function-param": require('./lib/rules/v5/resizeObserver-function-param'),
   "simpleList-remove-isCurrent": require('./lib/rules/v5/simpleList-remove-isCurrent'),
+  "spinner-svg-default": require('./lib/rules/v5/spinner-svg-default'),
   "tableComposable-remove-hasSelectableRowCaption": require('./lib/rules/v5/tableComposable-remove-hasSelectableRowCaption'),
   "toggle-remove-isPrimary": require('./lib/rules/v5/toggle-remove-isPrimary'),
   "toolbar-remove-visiblity": require('./lib/rules/v5/toolbar-remove-visiblity'),

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/spinner-svg-default.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/spinner-svg-default.js
@@ -1,12 +1,28 @@
-const { renameProp } = require('../../helpers');
+const { getPackageImports } = require('../../helpers');
 
 // https://github.com/patternfly/patternfly-react/pull/8183
 module.exports = {
   meta: { fixable: 'code' },
-  create: renameProp(
-    'Spinner',
-    { isSVG: '' },
-    () => `Spinner isSVG prop default value has changed from false to true.`
-  )
+  create: function(context) {
+    const spinnerImports = getPackageImports(context, '@patternfly/react-core')
+      .filter(specifier => specifier.imported.name == 'Spinner');
+      
+    return spinnerImports.length === 0 ? {} : {
+      JSXOpeningElement(node) {
+        if (spinnerImports.map(imp => imp.local.name).includes(node.name.name)) {
+          const svgAttribute = node.attributes.find(n => n.name && n.name.name === 'isSVG');
+          if (svgAttribute && svgAttribute?.value?.expression?.value !== false) {
+            context.report({
+              node,
+              message: `Spinner isSVG prop default value has changed from false to true.`,
+              fix(fixer) {
+                return fixer.replaceText(svgAttribute, ``);
+              }
+            });
+          }
+        }
+      }
+    };
+  }
 };
 

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/spinner-svg-default.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/spinner-svg-default.js
@@ -1,24 +1,3 @@
-// const { getPackageImports } = require('../../helpers');
-
-// module.exports = {
-//   meta: {},
-//   create: function(context) {
-//     const imports = getPackageImports(context, '@patternfly/react-core')
-//       .filter(specifier => specifier.imported.name === 'Spinner');
-      
-//     return imports.length === 0 ? {} : {
-//       JSXOpeningElement(node) {
-//         if (imports.map(imp => imp.local.name).includes(node.name.name)) {
-//             context.report({
-//               node,
-//               message: `Spinner isSVG prop default value has changed from false to true.`,
-//             });
-//         }
-//       }
-//     };
-//   }
-// };
-
 const { renameProp } = require('../../helpers');
 
 // https://github.com/patternfly/patternfly-react/pull/8183

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/spinner-svg-default.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/spinner-svg-default.js
@@ -1,0 +1,33 @@
+// const { getPackageImports } = require('../../helpers');
+
+// module.exports = {
+//   meta: {},
+//   create: function(context) {
+//     const imports = getPackageImports(context, '@patternfly/react-core')
+//       .filter(specifier => specifier.imported.name === 'Spinner');
+      
+//     return imports.length === 0 ? {} : {
+//       JSXOpeningElement(node) {
+//         if (imports.map(imp => imp.local.name).includes(node.name.name)) {
+//             context.report({
+//               node,
+//               message: `Spinner isSVG prop default value has changed from false to true.`,
+//             });
+//         }
+//       }
+//     };
+//   }
+// };
+
+const { renameProp } = require('../../helpers');
+
+// https://github.com/patternfly/patternfly-react/pull/8183
+module.exports = {
+  meta: { fixable: 'code' },
+  create: renameProp(
+    'Spinner',
+    { isSVG: '' },
+    () => `Spinner isSVG prop default value has changed from false to true.`
+  )
+};
+

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/spinner-svg-default.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/spinner-svg-default.js
@@ -1,0 +1,39 @@
+const ruleTester = require('../../ruletester');
+const rule = require('../../../lib/rules/v5/spinner-svg-default');
+
+ruleTester.run("spinner-svg-default", rule, {
+  valid: [
+    // {
+    //   code: `import { Spinner } from '@patternfly/react-core'; <Spinner isSVG />`,
+    // },
+    {
+      // No @patternfly/react-core import
+      code: `<Spinner isSVG />`,
+    },
+    {
+      code: `import { Spinner } from '@patternfly/react-core'; <Spinner />`,
+    },
+    {
+      // No @patternfly/react-core import
+      code: `<Spinner />`,
+    }
+  ],
+  invalid: [
+    // {
+    //   code:   `import { Spinner } from '@patternfly/react-core'; <Spinner />`,
+    //   output: `import { Spinner } from '@patternfly/react-core'; <Spinner />`,
+    //   errors: [{
+    //     message: `Spinner isSVG prop default value has changed from false to true.`,
+    //     type: "JSXOpeningElement",
+    //   }]
+    // },
+    {
+      code:   `import { Spinner } from '@patternfly/react-core'; <Spinner isSVG />`,
+      output: `import { Spinner } from '@patternfly/react-core'; <Spinner  />`,
+      errors: [{
+        message: `Spinner isSVG prop default value has changed from false to true.`,
+        type: "JSXOpeningElement",
+      }]
+    }
+  ]
+});

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/spinner-svg-default.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/spinner-svg-default.js
@@ -3,30 +3,15 @@ const rule = require('../../../lib/rules/v5/spinner-svg-default');
 
 ruleTester.run("spinner-svg-default", rule, {
   valid: [
-    // {
-    //   code: `import { Spinner } from '@patternfly/react-core'; <Spinner isSVG />`,
-    // },
-    {
-      // No @patternfly/react-core import
-      code: `<Spinner isSVG />`,
-    },
     {
       code: `import { Spinner } from '@patternfly/react-core'; <Spinner />`,
     },
     {
       // No @patternfly/react-core import
-      code: `<Spinner />`,
+      code: `<Spinner isSVG />`,
     }
   ],
   invalid: [
-    // {
-    //   code:   `import { Spinner } from '@patternfly/react-core'; <Spinner />`,
-    //   output: `import { Spinner } from '@patternfly/react-core'; <Spinner />`,
-    //   errors: [{
-    //     message: `Spinner isSVG prop default value has changed from false to true.`,
-    //     type: "JSXOpeningElement",
-    //   }]
-    // },
     {
       code:   `import { Spinner } from '@patternfly/react-core'; <Spinner isSVG />`,
       output: `import { Spinner } from '@patternfly/react-core'; <Spinner  />`,

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/spinner-svg-default.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/spinner-svg-default.js
@@ -7,6 +7,9 @@ ruleTester.run("spinner-svg-default", rule, {
       code: `import { Spinner } from '@patternfly/react-core'; <Spinner />`,
     },
     {
+      code: `import { Spinner } from '@patternfly/react-core'; <Spinner isSVG={false} />`,
+    },
+    {
       // No @patternfly/react-core import
       code: `<Spinner isSVG />`,
     }
@@ -14,6 +17,14 @@ ruleTester.run("spinner-svg-default", rule, {
   invalid: [
     {
       code:   `import { Spinner } from '@patternfly/react-core'; <Spinner isSVG />`,
+      output: `import { Spinner } from '@patternfly/react-core'; <Spinner  />`,
+      errors: [{
+        message: `Spinner isSVG prop default value has changed from false to true.`,
+        type: "JSXOpeningElement",
+      }]
+    },
+    {
+      code:   `import { Spinner } from '@patternfly/react-core'; <Spinner isSVG={true} />`,
       output: `import { Spinner } from '@patternfly/react-core'; <Spinner  />`,
       errors: [{
         message: `Spinner isSVG prop default value has changed from false to true.`,

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -340,5 +340,5 @@ In:
 Out:
 
 ```jsx
-<Tooltip    />
+<Tooltip     />
 ```

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -71,7 +71,7 @@ In:
 Out:
 
 ```jsx
-<Card  />
+<Card />
 ```
 
 ### datalist-remove-ondrags [(#163)](https://github.com/patternfly/pf-codemods/issues/163)
@@ -89,7 +89,7 @@ In:
 Out:
 
 ```jsx
-<DataList  />
+<DataList />
 ```
 
 ### divider-remove-isVertical [(#8199)](https://github.com/patternfly/patternfly-react/pull/8199)
@@ -141,7 +141,7 @@ In:
 Out:
 
 ```jsx
-<FileUpload  />
+<FileUpload />
 ```
 
 ### pagination-remove-ToggleTemplateProps [(#8134)](https://github.com/patternfly/patternfly-react/pull/8134)
@@ -182,15 +182,15 @@ In:
 
 ```jsx
 <Pagination
-  currPage='text'
-  paginationTitle='text'
-  toFirstPage='text'
-  toLastPage='text'
-  toNextPage='text'
-  toPreviousPage='text'
-  optionsToggle='text'
+  currPage="text"
+  paginationTitle="text"
+  toFirstPage="text"
+  toLastPage="text"
+  toNextPage="text"
+  toPreviousPage="text"
+  optionsToggle="text"
   defaultToFullPage
-  perPageComponenet='div'
+  perPageComponenet="div"
 />
 ```
 
@@ -198,13 +198,13 @@ Out:
 
 ```jsx
 <Pagination
-  currPageAriaLabel='text'
-  paginationAriaLabel='text'
-  toFirstPageAriaLabel='text'
-  toLastPageAriaLabel='text'
-  toNextPageAriaLabel='text'
-  toPreviousPageAriaLabel='text'
-  optionsToggleAriaLabel='text'
+  currPageAriaLabel="text"
+  paginationAriaLabel="text"
+  toFirstPageAriaLabel="text"
+  toLastPageAriaLabel="text"
+  toNextPageAriaLabel="text"
+  toPreviousPageAriaLabel="text"
+  optionsToggleAriaLabel="text"
   isLastFullPageShown
 />
 ```
@@ -250,7 +250,7 @@ In:
 Out:
 
 ```jsx
-<TableComposable  />
+<TableComposable />
 ```
 
 ### simpleList-remove-isCurrent [(#8132)](https://github.com/patternfly/patternfly-react/pull/8132)
@@ -269,6 +269,24 @@ Out:
 
 ```jsx
 <SimpleList isActive />
+```
+
+### spinner-svg-default [(#8183)](https://github.com/patternfly/patternfly-react/pull/8183)
+
+We've updated the Spinner to default to an svg, so the `isSVG` property is no longer required.
+
+#### Examples
+
+In:
+
+```jsx
+<Spinner isSVG />
+```
+
+Out:
+
+```jsx
+<Spinner />
 ```
 
 ### toggle-remove-isprimary [(#8179)](https://github.com/patternfly/patternfly-react/pull/8179)
@@ -322,5 +340,5 @@ In:
 Out:
 
 ```jsx
-<Tooltip     />
+<Tooltip />
 ```

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -71,7 +71,7 @@ In:
 Out:
 
 ```jsx
-<Card />
+<Card  />
 ```
 
 ### datalist-remove-ondrags [(#163)](https://github.com/patternfly/pf-codemods/issues/163)
@@ -89,7 +89,7 @@ In:
 Out:
 
 ```jsx
-<DataList />
+<DataList  />
 ```
 
 ### divider-remove-isVertical [(#8199)](https://github.com/patternfly/patternfly-react/pull/8199)
@@ -141,7 +141,7 @@ In:
 Out:
 
 ```jsx
-<FileUpload />
+<FileUpload  />
 ```
 
 ### pagination-remove-ToggleTemplateProps [(#8134)](https://github.com/patternfly/patternfly-react/pull/8134)
@@ -250,7 +250,7 @@ In:
 Out:
 
 ```jsx
-<TableComposable />
+<TableComposable  />
 ```
 
 ### simpleList-remove-isCurrent [(#8132)](https://github.com/patternfly/patternfly-react/pull/8132)
@@ -286,7 +286,7 @@ In:
 Out:
 
 ```jsx
-<Spinner />
+<Spinner  />
 ```
 
 ### toggle-remove-isprimary [(#8179)](https://github.com/patternfly/patternfly-react/pull/8179)
@@ -340,5 +340,5 @@ In:
 Out:
 
 ```jsx
-<Tooltip />
+<Tooltip    />
 ```

--- a/packages/pf-codemods/index.js
+++ b/packages/pf-codemods/index.js
@@ -35,7 +35,7 @@ function printResults(engine, results, format) {
   }
 
   // Don't show warnings
-  results.forEach(result => result.messages = result.messages.filter(message => message.severity === 2));
+  // results.forEach(result => result.messages = result.messages.filter(message => message.severity === 2));
 
   const output = formatter(results, {
     get rulesMeta() {

--- a/packages/pf-codemods/index.js
+++ b/packages/pf-codemods/index.js
@@ -35,7 +35,7 @@ function printResults(engine, results, format) {
   }
 
   // Don't show warnings
-  // results.forEach(result => result.messages = result.messages.filter(message => message.severity === 2));
+  results.forEach(result => result.messages = result.messages.filter(message => message.severity === 2));
 
   const output = formatter(results, {
     get rulesMeta() {


### PR DESCRIPTION
Closes #146

This codemod removes the redundant `isSVG` flag now that the default is true. 

I tried to get the codemod to throw a warning for all `Spinner` imports but I haven't quite figured out how to modify the severity of the message (which are all thrown as errors) so I'm holding off on that for now while I tinker with it more locally.