### PR TITLE
Charts - replace getResizeObserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lerna-output.txt
 .cache*
+.idea

--- a/packages/eslint-plugin-pf-codemods/index.js
+++ b/packages/eslint-plugin-pf-codemods/index.js
@@ -48,6 +48,7 @@ const rules = {
   "chartVoronoiContainer-remove-allowTooltip": require('./lib/rules/v4/chartVoronoiContainer-remove-allowTooltip'),
   "chart-remove-allowZoom": require('./lib/rules/v4/chartVoronoiContainer-remove-allowTooltip'),
   "react-icons-remove-icon": require('./lib/rules/v4/react-icons-remove-icon'),
+  "charts-resizeObserver-import": require('./lib/rules/v5/charts-resizeObserver-import'),
   "clipboardCopy-remove-popoverPosition": require('./lib/rules/v5/clipboardCopy-remove-popoverPosition'),
   "datalist-remove-ondrags": require('./lib/rules/v5/datalist-remove-ondrags'),
   "divider-remove-isVertical": require('./lib/rules/v5/divider-remove-isVertical'),

--- a/packages/eslint-plugin-pf-codemods/index.js
+++ b/packages/eslint-plugin-pf-codemods/index.js
@@ -60,7 +60,7 @@ const rules = {
   "spinner-svg-default": require('./lib/rules/v5/spinner-svg-default'),
   "tableComposable-remove-hasSelectableRowCaption": require('./lib/rules/v5/tableComposable-remove-hasSelectableRowCaption'),
   "tabs-rename-hasBorderBottom": require('./lib/rules/v5/tabs-rename-hasBorderBottom'),
-  "tabs-remove-hasSecondaryBorderBottom": require('./lib/rules/v5/tabs-rename-hasSecondaryBorderBottom'),
+  "tabs-remove-hasSecondaryBorderBottom": require('./lib/rules/v5/tabs-remove-hasSecondaryBorderBottom'),
   "toggle-remove-isPrimary": require('./lib/rules/v5/toggle-remove-isPrimary'),
   "toolbar-remove-visiblity": require('./lib/rules/v5/toolbar-remove-visiblity'),
   "tooltip-remove-props": require('./lib/rules/v5/tooltip-remove-props'),

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/charts-resizeObserver-import.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/charts-resizeObserver-import.js
@@ -1,0 +1,54 @@
+const { getPackageImports } = require("../../helpers");
+
+// https://github.com/patternfly/patternfly-react/pull/8533
+module.exports = {
+  meta: { fixable: "code" },
+  create: function (context) {
+    const chartResizeImport = getPackageImports(
+      context,
+      "@patternfly/react-charts"
+    ).filter((specifier) => specifier.imported.name == "getResizeObserver");
+
+    return chartResizeImport.length === 0
+      ? {}
+      : {
+          ImportDeclaration(node) {
+            if (node.source.value === "@patternfly/react-charts") {
+              context.report({
+                node,
+                message: `The getResizeObserver function has been removed from react-charts and should be imported from react-core instead.`,
+                fix(fixer) {
+                  const fixes = [];
+                  if (node.specifiers.length > 1) {
+                    const { range } = chartResizeImport[0];
+                    const nextToken = context
+                      .getSourceCode()
+                      .getTokenAfter(chartResizeImport[0]);
+                    const rangeEnd =
+                      nextToken && nextToken.value === ","
+                        ? range[1] + 1
+                        : range[1];
+
+                    fixes.push(
+                      fixer.replaceTextRange([range[0], rangeEnd], "")
+                    );
+                    fixes.push(
+                      fixer.insertTextAfterRange(
+                        node.range,
+                        "import {getResizeObserver} from '@patternfly/react-core';"
+                      )
+                    );
+                  } else {
+                    fixes.push(
+                      fixer.replaceText(node.source, "'@patternfly/react-core'")
+                    );
+                  }
+
+                  return fixes;
+                },
+              });
+            }
+          },
+        };
+  },
+};

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/charts-resizeObserver-import.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/charts-resizeObserver-import.js
@@ -35,7 +35,7 @@ module.exports = {
                     fixes.push(
                       fixer.insertTextAfterRange(
                         node.range,
-                        "import {getResizeObserver} from '@patternfly/react-core';"
+                        "\nimport {getResizeObserver} from '@patternfly/react-core';"
                       )
                     );
                   } else {

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/charts-resizeObserver-import.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/charts-resizeObserver-import.js
@@ -1,0 +1,45 @@
+const ruleTester = require("../../ruletester");
+const rule = require("../../../lib/rules/v5/charts-resizeObserver-import");
+
+ruleTester.run("charts-resizeObserver-import", rule, {
+  valid: [
+    {
+      code: `import { getResizeObserver } from '@patternfly/react-core';`,
+    },
+    {
+      code: `import { Chart } from '@patternfly/react-charts';`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import { getResizeObserver } from '@patternfly/react-charts';`,
+      output: `import { getResizeObserver } from '@patternfly/react-core';`,
+      errors: [
+        {
+          message: `The getResizeObserver function has been removed from react-charts and should be imported from react-core instead.`,
+          type: "ImportDeclaration",
+        },
+      ],
+    },
+    {
+      code: `import { getResizeObserver, Chart } from '@patternfly/react-charts';`,
+      output: `import {  Chart } from '@patternfly/react-charts';import {getResizeObserver} from '@patternfly/react-core';`,
+      errors: [
+        {
+          message: `The getResizeObserver function has been removed from react-charts and should be imported from react-core instead.`,
+          type: "ImportDeclaration",
+        },
+      ],
+    },
+    {
+      code: `import { Chart, getResizeObserver, ChartArea } from '@patternfly/react-charts';`,
+      output: `import { Chart,  ChartArea } from '@patternfly/react-charts';import {getResizeObserver} from '@patternfly/react-core';`,
+      errors: [
+        {
+          message: `The getResizeObserver function has been removed from react-charts and should be imported from react-core instead.`,
+          type: "ImportDeclaration",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/charts-resizeObserver-import.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/charts-resizeObserver-import.js
@@ -23,7 +23,7 @@ ruleTester.run("charts-resizeObserver-import", rule, {
     },
     {
       code: `import { getResizeObserver, Chart } from '@patternfly/react-charts';`,
-      output: `import {  Chart } from '@patternfly/react-charts';import {getResizeObserver} from '@patternfly/react-core';`,
+      output: `import {  Chart } from '@patternfly/react-charts';\nimport {getResizeObserver} from '@patternfly/react-core';`,
       errors: [
         {
           message: `The getResizeObserver function has been removed from react-charts and should be imported from react-core instead.`,
@@ -33,7 +33,7 @@ ruleTester.run("charts-resizeObserver-import", rule, {
     },
     {
       code: `import { Chart, getResizeObserver, ChartArea } from '@patternfly/react-charts';`,
-      output: `import { Chart,  ChartArea } from '@patternfly/react-charts';import {getResizeObserver} from '@patternfly/react-core';`,
+      output: `import { Chart,  ChartArea } from '@patternfly/react-charts';\nimport {getResizeObserver} from '@patternfly/react-core';`,
       errors: [
         {
           message: `The getResizeObserver function has been removed from react-charts and should be imported from react-core instead.`,

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -168,7 +168,7 @@ Out:
 
 ### pagination-remove-ToggleTemplateProps [(#8134)](https://github.com/patternfly/patternfly-react/pull/8134)
 
-We've removed the depracated `ToggleTemplateProps` prop and replaced it with `PaginationToggleTemplateProps`.
+We've removed the deprecated `ToggleTemplateProps` prop and replaced it with `PaginationToggleTemplateProps`.
 
 #### Examples
 
@@ -338,7 +338,7 @@ We've updated the default value of the `getResizeObserver` helper function's thi
 
 ### tableComposable-remove-hasSelectableRowCaption [(#8352)](https://github.com/patternfly/patternfly-react/pull/8352)
 
-We've removed the depracated `hasSelectableRowCaption` prop.
+We've removed the deprecated `hasSelectableRowCaption` prop.
 
 #### Examples
 
@@ -484,4 +484,22 @@ Out:
 
 ```jsx
 <Tooltip     />
+```
+
+### chart-resizeObserver-function [(#8533)](https://github.com/patternfly/patternfly-react/pull/8533)
+
+We've removed the `getResizeObserver` function from react-charts in favor of react-core's `getResizeObserver`. This helper function now has a third parameter, `useRequestAnimationFrame`, and allows a single function to be maintained going forward.
+
+#### Examples
+
+In:
+
+```jsx
+import { getResizeObserver } from '@patternfly/react-charts';
+```
+
+Out:
+
+```jsx
+import { getResizeObserver } from '@patternfly/react-core';
 ```

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -76,6 +76,24 @@ Out:
 <Card  />
 ```
 
+### chart-getResizeObserver [(#8533)](https://github.com/patternfly/patternfly-react/pull/8533)
+
+We've removed the `getResizeObserver` function from react-charts in favor of react-core's `getResizeObserver`. This helper function now has a third parameter, `useRequestAnimationFrame`, and allows a single function to be maintained going forward.
+
+#### Examples
+
+In:
+
+```jsx
+import { getResizeObserver } from '@patternfly/react-charts';
+```
+
+Out:
+
+```jsx
+import { getResizeObserver } from '@patternfly/react-core';
+```
+
 ### clipboardCopy-remove-popoverPosition [(#8226)](https://github.com/patternfly/patternfly-react/pull/8226)
 
 We've removed the PopoverPosition type for the `position` prop on both ClipboardCopy and ClipboardCopyButton.
@@ -484,22 +502,4 @@ Out:
 
 ```jsx
 <Tooltip     />
-```
-
-### chart-resizeObserver-function [(#8533)](https://github.com/patternfly/patternfly-react/pull/8533)
-
-We've removed the `getResizeObserver` function from react-charts in favor of react-core's `getResizeObserver`. This helper function now has a third parameter, `useRequestAnimationFrame`, and allows a single function to be maintained going forward.
-
-#### Examples
-
-In:
-
-```jsx
-import { getResizeObserver } from '@patternfly/react-charts';
-```
-
-Out:
-
-```jsx
-import { getResizeObserver } from '@patternfly/react-core';
 ```


### PR DESCRIPTION
Replaced react-chart `getResizeObserver` with same function from react-core.

Related to PR https://github.com/patternfly/patternfly-react/pull/8533