### PR TITLE
feat(Pagination): add codemod for optionstoggle

### DIFF
--- a/packages/eslint-plugin-pf-codemods/index.js
+++ b/packages/eslint-plugin-pf-codemods/index.js
@@ -53,6 +53,7 @@ const rules = {
   "datalist-remove-ondrags": require('./lib/rules/v5/datalist-remove-ondrags'),
   "divider-remove-isVertical": require('./lib/rules/v5/divider-remove-isVertical'),
   "fileUpload-remove-onChange": require('./lib/rules/v5/fileUpload-remove-onChange'),
+  "pagination-optionsToggle": require('./lib/rules/v5/pagination-optionsToggle'),
   "pagination-remove-ToggleTemplateProps": require('./lib/rules/v5/pagination-remove-ToggleTemplateProps'),
   "pagination-rename-props": require('./lib/rules/v5/pagination-rename-props'),
   "resizeObserver-function-param": require('./lib/rules/v5/resizeObserver-function-param'),

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/pagination-optionsToggle.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/pagination-optionsToggle.js
@@ -1,0 +1,21 @@
+const { getPackageImports } = require('../../helpers');
+
+  // https://github.com/patternfly/patternfly-react/pull/8319
+  module.exports = {
+    meta: {},
+    create: function(context) {
+      const optionsToggleImport = getPackageImports(context, '@patternfly/react-core')
+        .filter(specifier => specifier.imported.name == 'OptionsToggle');
+  
+      return optionsToggleImport.length === 0 ? {} : {
+        JSXOpeningElement(node) {
+          if (optionsToggleImport.map(imp => imp.local.name).includes(node.name.name)) {
+            context.report({
+              node,
+              message: `OptionsToggle has been removed and MenuToggle should be used instead. PaginationOptionsMenu has been refactored to use MenuToggle.`
+            });
+          }
+        }
+      };
+    }
+  };

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/pagination-optionsToggle.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/pagination-optionsToggle.js
@@ -1,0 +1,21 @@
+const ruleTester = require('../../ruletester');
+const rule = require('../../../lib/rules/v5/pagination-optionsToggle');
+
+ruleTester.run("pagination-optionsToggle", rule, {
+  valid: [
+    {
+      // No @patternfly/react-core import
+      code: `<OptionsToggle />`,
+    }
+  ],
+  invalid: [
+    {
+      code:   `import { OptionsToggle } from '@patternfly/react-core'; <OptionsToggle />`,
+      output: `import { OptionsToggle } from '@patternfly/react-core'; <OptionsToggle />`,
+      errors: [{
+        message: `OptionsToggle has been removed and MenuToggle should be used instead. PaginationOptionsMenu has been refactored to use MenuToggle.`,
+        type: "JSXOpeningElement",
+      }]
+    }
+  ]
+});

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -184,6 +184,10 @@ Out:
 <FileUpload  />
 ```
 
+### pagination-optionsToggle [(#8319)](https://github.com/patternfly/patternfly-react/pull/8319)
+
+We've removed the `OptionsToggle` used by `Pagination` and replaced it with `Menu` and `MenuToggle`.
+
 ### pagination-remove-ToggleTemplateProps [(#8134)](https://github.com/patternfly/patternfly-react/pull/8134)
 
 We've removed the deprecated `ToggleTemplateProps` prop and replaced it with `PaginationToggleTemplateProps`.


### PR DESCRIPTION
Closes #162

Doesn't have a fixer because replacing the component would be more complex than a 1:1 replacement, and also because it's unlikely this component is being used directly. If we figure out how to set the severity level this would be a good one to update to warn instead.