### PR TITLE
feat(MenuItemAction): made aria-label prop required

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/menuItemAction-ariaLabel-required.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/menuItemAction-ariaLabel-required.js
@@ -1,0 +1,34 @@
+const { getPackageImports } = require("../../helpers");
+
+// https://github.com/patternfly/patternfly-react/pull/8617
+module.exports = {
+  create: function (context) {
+    const menuItemActionImport = getPackageImports(
+      context,
+      "@patternfly/react-core"
+    ).filter((specifier) => specifier.imported.name == "MenuItemAction");
+
+    return menuItemActionImport.length === 0
+      ? {}
+      : {
+          JSXOpeningElement(node) {
+            if (
+              menuItemActionImport
+                .map((imp) => imp.local.name)
+                .includes(node.name.name)
+            ) {
+              const existingAriaLabel = node.attributes.find(
+                (attr) => attr.name && attr.name.name === "aria-label"
+              );
+
+              if (!existingAriaLabel) {
+                context.report({
+                  node,
+                  message: `The aria-label prop for ${node.name.name} is now required.`,
+                });
+              }
+            }
+          },
+        };
+  },
+};

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/menuItemAction-ariaLabel-required.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/menuItemAction-ariaLabel-required.js
@@ -1,0 +1,25 @@
+const ruleTester = require("../../ruletester");
+const rule = require("../../../lib/rules/v5/menuItemAction-ariaLabel-required");
+
+ruleTester.run("menuItemAction-ariaLabel-required", rule, {
+  valid: [
+    {
+      code: `import { MenuItemAction } from '@patternfly/react-core'; <MenuItemAction aria-label="Test" />`,
+    },
+    {
+      // No @patternfly/react-core import
+      code: `<MenuItemAction />`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import { MenuItemAction } from '@patternfly/react-core'; <MenuItemAction />`,
+      errors: [
+        {
+          message: `The aria-label prop for MenuItemAction is now required.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -282,6 +282,10 @@ Out:
 
 We've updated the default value of the `aria-label` attribute for Nav with a `horizontal-subnav` variant to "local" (previously the default value was "Global").
 
+### menuItemAction-ariaLabel-required [(#8617)](https://github.com/patternfly/patternfly-react/pull/8617)
+
+We've update the `aria-label` prop on MenuItemAction, making it required instead of optional.
+
 ### pagination-optionsToggle [(#8319)](https://github.com/patternfly/patternfly-react/pull/8319)
 
 We've removed the `OptionsToggle` used by `Pagination` and replaced it with `Menu` and `MenuToggle`.

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -5,6 +5,7 @@ import { CodeEditor } from "@patternfly/react-code-editor";
 import { DropdownToggle, Toggle } from "@patternfly/react-core";
 import { FileUpload } from "@patternfly/react-core";
 import { KEY_CODES } from "@patternfly/react-core";
+import { MenuItemAction } from "@patternfly/react-core";
 import { MultipleFileUpload } from "@patternfly/react-core";
 import { Nav } from "@patternfly/react-core";
 import { Tabs } from "@patternfly/react-core";
@@ -13,6 +14,7 @@ import { WizardFooter } from "@patternfly/react-core/next";
 
 <>
   <DropdownToggle isPrimary />
+  <MenuItemAction />
   <Nav variant='horizontal-subnav' />;
   <Toggle isPrimary />
 </>;


### PR DESCRIPTION
Closes #228 

Opted to not pass in a stock `aria-label` similar to v4's ChipGroup update for `categoryName`, as since this prop won't be visually seen it might be more advantageous for consumers to manually pass the prop in based on the component's context.