### PR TITLE
chore(hasCheck): Updated prop name to hasCheckbox

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/hasCheck-prop-rename.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/hasCheck-prop-rename.js
@@ -1,0 +1,47 @@
+const { getPackageImports } = require("../../helpers");
+
+// https://github.com/patternfly/patternfly-react/pull/8403
+module.exports = {
+  meta: { fixable: "code" },
+  create: function (context) {
+    const importsWithHasCheck = [
+      ...getPackageImports(context, "@patternfly/react-core").filter(
+        (specifier) =>
+          ["MenuItem", "TreeView"].includes(specifier.imported.name)
+      ),
+      ...getPackageImports(context, "@patternfly/react-core/next").filter(
+        (specifier) => specifier.imported.name === "SelectOption"
+      ),
+    ];
+
+    return importsWithHasCheck.length === 0
+      ? {}
+      : {
+          JSXOpeningElement(node) {
+            if (
+              importsWithHasCheck
+                .map((imp) => imp.local.name)
+                .includes(node.name.name)
+            ) {
+              const hasCheckAttribute = node.attributes.find(
+                (attribute) =>
+                  attribute.name && attribute.name.name === "hasCheck"
+              );
+
+              if (hasCheckAttribute) {
+                context.report({
+                  node,
+                  message: `The 'hasCheck' prop for ${node.name.name} has been renamed to 'hasCheckbox'.`,
+                  fix(fixer) {
+                    return fixer.replaceTextRange(
+                      hasCheckAttribute.range,
+                      "hasCheckbox"
+                    );
+                  },
+                });
+              }
+            }
+          },
+        };
+  },
+};

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/hasCheck-prop-rename.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/hasCheck-prop-rename.js
@@ -1,0 +1,54 @@
+const ruleTester = require("../../ruletester");
+const rule = require("../../../lib/rules/v5/hasCheck-prop-rename");
+
+ruleTester.run("hasCheck-prop-rename", rule, {
+  valid: [
+    {
+      code: `import { SelectOption } from '@patternfly/react-core'; <SelectOption hasCheck />`,
+    },
+    {
+      // No @patternfly/react-core import
+      code: `<SelectOption hasCheck />`,
+    },
+    {
+      // No @patternfly/react-core import
+      code: `<TreeView hasCheck />`,
+    },
+    {
+      // No @patternfly/react-core import
+      code: `<MenuItem hasCheck />`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import { SelectOption } from '@patternfly/react-core/next'; <SelectOption hasCheck />`,
+      output: `import { SelectOption } from '@patternfly/react-core/next'; <SelectOption hasCheckbox />`,
+      errors: [
+        {
+          message: `The 'hasCheck' prop for SelectOption has been renamed to 'hasCheckbox'.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    {
+      code: `import { MenuItem } from '@patternfly/react-core'; <MenuItem hasCheck />`,
+      output: `import { MenuItem } from '@patternfly/react-core'; <MenuItem hasCheckbox />`,
+      errors: [
+        {
+          message: `The 'hasCheck' prop for MenuItem has been renamed to 'hasCheckbox'.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    {
+      code: `import { TreeView } from '@patternfly/react-core'; <TreeView hasCheck />`,
+      output: `import { TreeView } from '@patternfly/react-core'; <TreeView hasCheckbox />`,
+      errors: [
+        {
+          message: `The 'hasCheck' prop for TreeView has been renamed to 'hasCheckbox'.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/toggle-remove-isPrimary.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/toggle-remove-isPrimary.js
@@ -1,5 +1,5 @@
-const ruleTester = require('../../ruletester');
-const rule = require('../../../lib/rules/v5/toggle-remove-isPrimary');
+const ruleTester = require("../../ruletester");
+const rule = require("../../../lib/rules/v5/toggle-remove-isPrimary");
 
 ruleTester.run("toggle-remove-isPrimary", rule, {
   valid: [
@@ -9,16 +9,18 @@ ruleTester.run("toggle-remove-isPrimary", rule, {
     {
       // No @patternfly/react-core import
       code: `<Toggle isPrimary />`,
-    }
+    },
   ],
   invalid: [
     {
-      code:   `import { Toggle } from '@patternfly/react-core'; <Toggle isPrimary />`,
+      code: `import { Toggle } from '@patternfly/react-core'; <Toggle isPrimary />`,
       output: `import { Toggle } from '@patternfly/react-core'; <Toggle toggleVariant="primary" />`,
-      errors: [{
-        message: `isPrimary prop has been removed for Toggle and replaced by using 'primary' value on the toggleVariant prop.`,
-        type: "JSXOpeningElement",
-      }]
-    }
-  ]
+      errors: [
+        {
+          message: `isPrimary prop has been removed for Toggle and replaced by using 'primary' value on the toggleVariant prop.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+  ],
 });

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -352,6 +352,28 @@ Out:
 <FileUpload  />
 ```
 
+### hasCheck-prop-rename [(#8403)](https://github.com/patternfly/patternfly-react/pull/8403)
+
+We've renamed the `hasCheck` prop for TreeView, MenuItem, and the Next implementation of SelectOption to `hasCheckbox`.
+
+#### Examples
+
+In:
+
+```jsx
+<SelectOption hasCheck />
+<TreeView hasCheck />
+<MenuItem hasCheck />
+```
+
+Out:
+
+```jsx
+<SelectOption hasCheckbox />
+<TreeView hasCheckbox />
+<MenuItem hasCheckbox />
+```
+
 ### horizontalSubnav-ariaLabel [(#8213)](https://github.com/patternfly/patternfly-react/pull/8213)
 
 We've updated the default value of the `aria-label` attribute for Nav with a `horizontal-subnav` variant to "local" (previously the default value was "Global").

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -3,23 +3,33 @@ import { Alert } from "@patternfly/react-core";
 import { ApplicationLauncher } from "@patternfly/react-core";
 import { Card } from "@patternfly/react-core";
 import { CodeEditor } from "@patternfly/react-code-editor";
-import { DropdownToggle, Toggle, Button, Spinner } from "@patternfly/react-core";
+import {
+  DropdownToggle,
+  Toggle,
+  Button,
+  Spinner,
+} from "@patternfly/react-core";
 import { FileUpload } from "@patternfly/react-core";
 import { KEY_CODES } from "@patternfly/react-core";
-import { MenuItemAction } from "@patternfly/react-core";
+import { MenuItem, MenuItemAction } from "@patternfly/react-core";
 import { MultipleFileUpload } from "@patternfly/react-core";
 import { Nav } from "@patternfly/react-core";
 import { Tabs } from "@patternfly/react-core";
+import { TreeView } from "@patternfly/react-core";
 import { Wizard } from "@patternfly/react-core";
+import { SelectOption } from "@patternfly/react-core/next";
 import { WizardFooter } from "@patternfly/react-core/next";
 
 <>
   <Alert aria-label='tester' />
   <DropdownToggle isPrimary />
+  <MenuItem hasCheck />
   <MenuItemAction />
   <Nav variant='horizontal-subnav' />;
+  <SelectOption hasCheck />
   <Toggle isPrimary />
   <Button isLarge />
   <Button isSmall />
   <Spinner isSVG />
+  <TreeView hasCheck />
 </>;


### PR DESCRIPTION
Closes #194 

Omitted TreeViewListItem and TreeViewRoot since they aren't exported currently. 