### PR TITLE
fix(Charts): fixed broken tooltip examples

### DIFF
--- a/packages/eslint-plugin-pf-codemods/index.js
+++ b/packages/eslint-plugin-pf-codemods/index.js
@@ -16,6 +16,7 @@ const v4rules = createListOfRules("4");
 const warningRules = [
   "applicationLauncher-warn-input",
   "card-warn-component",
+  "charts-tooltip-warning",
   "datePicker-warn-appendTo-default-value-changed",
   "horizontalSubnav-ariaLabel",
   "onToggle-warn-event",

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/charts-resizeObserver-import.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/charts-resizeObserver-import.js
@@ -13,7 +13,13 @@ module.exports = {
       ? {}
       : {
           ImportDeclaration(node) {
-            if (node.source.value === "@patternfly/react-charts") {
+            if (
+              node.specifiers.filter((specifier) =>
+                chartResizeImport
+                  .map((imp) => imp.local.name)
+                  .includes(specifier.imported.name)
+              ).length
+            ) {
               context.report({
                 node,
                 message: `The getResizeObserver function has been removed from react-charts and should be imported from react-core instead.`,

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/charts-tooltip-warning.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/charts-tooltip-warning.js
@@ -1,0 +1,32 @@
+const { getPackageImports } = require("../../helpers");
+
+// https://github.com/patternfly/patternfly-react/pull/8533
+module.exports = {
+  meta: {},
+  create: function (context) {
+    const chartImports = getPackageImports(context, "@patternfly/react-charts");
+    const tooltipImport = getPackageImports(
+      context,
+      "@patternfly/react-core"
+    ).filter((specifier) => specifier.imported.name == "Tooltip");
+
+    return !chartImports.length || !tooltipImport.length
+      ? {}
+      : {
+          ImportDeclaration(node) {
+            if (
+              node.specifiers.filter((specifier) =>
+                tooltipImport
+                  .map((imp) => imp.local.name)
+                  .includes(specifier.imported.name)
+              ).length
+            ) {
+              context.report({
+                node,
+                message: `The react-core Tooltip should be wrapped inside a foreignObject when used inside a react-charts component. The Tooltip may not render properly otherwise due to it outputting a div element inside an svg element.`,
+              });
+            }
+          },
+        };
+  },
+};

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/charts-tooltip-warning.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/charts-tooltip-warning.js
@@ -1,0 +1,25 @@
+const ruleTester = require("../../ruletester");
+const rule = require("../../../lib/rules/v5/charts-tooltip-warning");
+
+ruleTester.run("charts-tooltip-warning", rule, {
+  valid: [
+    {
+      code: `import { Chart } from '@patternfly/react-charts';`,
+    },
+    {
+      code: `import { Tooltip } from '@patternfly/react-core';`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import { Chart } from '@patternfly/react-charts'; import { Tooltip } from '@patternfly/react-core';`,
+      output: `import { Chart } from '@patternfly/react-charts'; import { Tooltip } from '@patternfly/react-core';`,
+      errors: [
+        {
+          message: `The react-core Tooltip should be wrapped inside a foreignObject when used inside a react-charts component. The Tooltip may not render properly otherwise due to it outputting a div element inside an svg element.`,
+          type: "ImportDeclaration",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -192,6 +192,12 @@ return (
 );
 ```
 
+### charts-tooltip-warning [(#8592)](https://github.com/patternfly/patternfly-react/pull/8592)
+
+When using the `react-core` Tooltip component inside of a `react-charts` component, the Tooltip should be wrapped inside a `foreignObject`. The Tooltip may not render properly otherwise due to it outputting a `<div>` element inside an `<svg>` element.
+
+This rule will raise a warning when Tooltip is imported from `@patternfly/react-core` and at least one other import is from `@patternfly/react-charts`, but will not update any code.
+
 ### clipboardCopy-remove-popoverPosition [(#8226)](https://github.com/patternfly/patternfly-react/pull/8226)
 
 We've removed the PopoverPosition type for the `position` prop on both ClipboardCopy and ClipboardCopyButton.

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -1,3 +1,4 @@
+import { ChartLegend, getResizeObserver } from "@patternfly/react-charts";
 import { CodeEditor } from "@patternfly/react-code-editor";
 import {
   AccordionExpandableContent,
@@ -19,6 +20,7 @@ import {
   Spinner,
   Tabs,
   Toggle,
+  Tooltip,
   TreeView,
   Wizard,
 } from "@patternfly/react-core";


### PR DESCRIPTION
Closes #234 

Also updated some logic for the getResizeObserver file so that if there are two separate import statements from react-charts, only getResizeObserver will be updated to react-core (before it would update all imports from react-charts if getResizeObserver was found).