### PR TITLE
chore(Tooltip): renamed reference prop to triggerRef

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/tooltip-rename-reference.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/tooltip-rename-reference.js
@@ -1,0 +1,11 @@
+const { renameProp } = require('../../helpers');
+
+  // https://github.com/patternfly/patternfly-react/pull/8733
+  module.exports = {
+    meta: { fixable: 'code' },
+    create: renameProp(
+      'Tooltip',
+      {'reference': 'triggerRef'},
+      node =>  `The 'reference' prop for ${node.name.name} has been renamed to 'triggerRef'.`
+    ),
+  };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/tooltip-rename-reference.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/tooltip-rename-reference.js
@@ -6,6 +6,6 @@ const { renameProp } = require('../../helpers');
     create: renameProp(
       'Tooltip',
       {'reference': 'triggerRef'},
-      node =>  `The 'reference' prop for ${node.name.name} has been renamed to 'triggerRef'.`
+      node =>  `reference prop has been removed for ${node.name.name} and replaced with the triggerRef prop.`
     ),
   };

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/tooltip-rename-reference.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/tooltip-rename-reference.js
@@ -1,0 +1,24 @@
+const ruleTester = require('../../ruletester');
+const rule = require('../../../lib/rules/v5/tooltip-rename-reference');
+
+ruleTester.run("tooltip-rename-reference", rule, {
+  valid: [
+    {
+      code: `import { Tooltip } from '@patternfly/react-core'; <Tooltip triggerRef />`,
+    },
+    {
+      // No @patternfly/react-core import
+      code: `<Tooltip reference />`,
+    }
+  ],
+  invalid: [
+    {
+      code:   `import { Tooltip } from '@patternfly/react-core'; <Tooltip reference />`,
+      output: `import { Tooltip } from '@patternfly/react-core'; <Tooltip triggerRef />`,
+      errors: [{
+        message: `reference prop has been removed for Tooltip and replaced with the triggerRef prop.`,
+        type: "JSXOpeningElement",
+      }]
+    }
+  ]
+});

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -944,6 +944,24 @@ Out:
 <Tooltip     />
 ```
 
+### tooltip-rename-reference [(#8733)](https://github.com/patternfly/patternfly-react/pull/8733)
+
+We've renamed the `reference` property to `triggerRef` in Tooltip.
+
+#### Examples
+
+In:
+
+```jsx
+<Tooltip reference={componentRef} />
+```
+
+Out:
+
+```jsx
+<Tooltip triggerRef={componentRef} />
+```
+
 ### wizard-warn-button-order [(#8409)](https://github.com/patternfly/patternfly-react/pull/8409)
 
 The order of the "next" and "back" buttons in the Wizard has been updated, with the "next" button now coming after the "back" button. This update has also been made in the Next implementation of the WizardFooter. We recommend updating any tests that may rely on relative selectors and updating any composable implementations to match this new button order.

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -72,5 +72,6 @@ const newTheme = getCustomTheme("1", "2", "3");
   <SelectOption hasCheck />
   <Spinner isSVG />
   <Toggle isPrimary />
+  <Tooltip reference />
   <TreeView hasCheck />
 </>;


### PR DESCRIPTION
Closes #304, relates to https://github.com/patternfly/patternfly-react/pull/8733