### PR TITLE
feat(Banner): updated variant types

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/banner-update-variant.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/banner-update-variant.js
@@ -24,14 +24,18 @@ module.exports = {
                 (attribute) => attribute.name.name === "variant"
               );
 
-              if (variantProp) {
+              if (
+                variantProp &&
+                (variantMap[variantProp.value?.value] ||
+                  variantProp.value?.type !== "Literal")
+              ) {
                 context.report({
                   node,
                   message: `The "variant" prop type for Banner has been updated. "default" is still a valid value, but the previous status values of "info", "success", "warning", and "danger" have been replaced with color values of "blue", "green", "gold", and "red", respectively.`,
                   fix(fixer) {
                     const fixes = [];
 
-                    if (variantMap[variantProp.value?.value]) {
+                    if (variantMap[variantProp.value.value]) {
                       fixes.push(
                         fixer.replaceText(
                           variantProp.value,

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/banner-update-variant.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/banner-update-variant.js
@@ -1,0 +1,51 @@
+const { getPackageImports } = require("../../helpers");
+
+module.exports = {
+  meta: { fixable: "code" },
+  create: function (context) {
+    const bannerImport = getPackageImports(
+      context,
+      "@patternfly/react-core"
+    ).find((specifier) => specifier.imported.name == "Banner");
+
+    const variantMap = {
+      info: "blue",
+      danger: "red",
+      warning: "gold",
+      success: "green",
+    };
+
+    return !bannerImport
+      ? {}
+      : {
+          JSXOpeningElement(node) {
+            if (bannerImport.local.name === node.name.name) {
+              const variantProp = node.attributes.find(
+                (attribute) => attribute.name.name === "variant"
+              );
+
+              if (variantProp) {
+                context.report({
+                  node,
+                  message: `The "variant" prop type for Banner has been updated. "default" is still a valid value, but the previous status values of "info", "success", "warning", and "danger" have been replaced with color values of "blue", "green", "gold", and "red", respectively.`,
+                  fix(fixer) {
+                    const fixes = [];
+
+                    if (variantMap[variantProp.value?.value]) {
+                      fixes.push(
+                        fixer.replaceText(
+                          variantProp.value,
+                          `"${variantMap[variantProp.value.value]}"`
+                        )
+                      );
+                    }
+
+                    return fixes;
+                  },
+                });
+              }
+            }
+          },
+        };
+  },
+};

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/banner-update-variant.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/banner-update-variant.js
@@ -1,7 +1,6 @@
 const ruleTester = require("../../ruletester");
 const rule = require("../../../lib/rules/v5/banner-update-variant");
 const variantMap = [
-  { default: "default" },
   { info: "blue" },
   { danger: "red" },
   { warning: "gold" },
@@ -14,11 +13,27 @@ ruleTester.run("banner-update-variant", rule, {
       code: `import { Banner } from '@patternfly/react-core'; <Banner />`,
     },
     {
+      code: `import { Banner } from '@patternfly/react-core'; <Banner variant="default" />`,
+    },
+    {
+      code: `import { Banner } from '@patternfly/react-core'; <Banner variant="blue" />`,
+    },
+    {
       // No @patternfly/react-core import
       code: `<Banner variant="danger" />`,
     },
   ],
   invalid: [
+    {
+      code: `import { Banner } from '@patternfly/react-core'; const status = 'default'; <Banner variant={status} />`,
+      output: `import { Banner } from '@patternfly/react-core'; const status = 'default'; <Banner variant={status} />`,
+      errors: [
+        {
+          message: `The "variant" prop type for Banner has been updated. "default" is still a valid value, but the previous status values of "info", "success", "warning", and "danger" have been replaced with color values of "blue", "green", "gold", and "red", respectively.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
     ...variantMap.map((variant) => {
       const key = Object.keys(variant);
 

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/banner-update-variant.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/banner-update-variant.js
@@ -1,0 +1,37 @@
+const ruleTester = require("../../ruletester");
+const rule = require("../../../lib/rules/v5/banner-update-variant");
+const variantMap = [
+  { default: "default" },
+  { info: "blue" },
+  { danger: "red" },
+  { warning: "gold" },
+  { success: "green" },
+];
+
+ruleTester.run("banner-update-variant", rule, {
+  valid: [
+    {
+      code: `import { Banner } from '@patternfly/react-core'; <Banner />`,
+    },
+    {
+      // No @patternfly/react-core import
+      code: `<Banner variant="danger" />`,
+    },
+  ],
+  invalid: [
+    ...variantMap.map((variant) => {
+      const key = Object.keys(variant);
+
+      return {
+        code: `import { Banner } from '@patternfly/react-core'; <Banner variant="${key}" />`,
+        output: `import { Banner } from '@patternfly/react-core'; <Banner variant="${variant[key]}" />`,
+        errors: [
+          {
+            message: `The "variant" prop type for Banner has been updated. "default" is still a valid value, but the previous status values of "info", "success", "warning", and "danger" have been replaced with color values of "blue", "green", "gold", and "red", respectively.`,
+            type: "JSXOpeningElement",
+          },
+        ],
+      };
+    }),
+  ],
+});

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -116,6 +116,31 @@ Out:
 
 We've updated the internal input in ApplicationLauncher to the PatternFly SearchInput. Any relative selectors, such as in unit tests, may need to be updated.
 
+### banner-update-variant [(#8204)](https://github.com/patternfly/patternfly-react/issues/8204)
+
+We've updated the `variant` prop type for Banner. `"default"` is still a valid value, but the following status values have been replaced with color values:
+
+| Old status value | New color value |
+| - | - |
+| info | blue |
+| danger | red |
+| success | green |
+| warning | gold |
+
+#### Examples
+
+In:
+
+```jsx
+<Banner variant="danger" />
+```
+
+Out:
+
+```jsx
+<Banner variant="red" />
+```
+
 ### button-remove-isSmallisLarge [(#8144)](https://github.com/patternfly/patternfly-react/pull/8144)
 
 We've removed the `isSmall` and `isLarge` props for Button and replaced them with the `size` prop using the values `"sm"` and `"lg"`, respectively.

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -13,6 +13,7 @@ import {
   Alert,
   ApplicationLauncher,
   BadgeToggle,
+  Banner,
   Button,
   Card,
   DataList,
@@ -56,6 +57,7 @@ const newTheme = getCustomTheme("1", "2", "3");
   <Alert titleHeadingLevel={"h4"}/>
   <ApplicationLauncher onToggle={} />
   <BadgeToggle onToggle={} />
+  <Banner variant="danger" />
   <Button isLarge />
   <Button isSmall />
   <Chart themeVariant />


### PR DESCRIPTION
Closes #331 

Because of how much variety there may be when it comes to passing some variable/function reference to the `variant` prop, I opted to only include a fix for when a string is passed in. Otherwise an error message will be output if the `variant` prop is used at all (even if "default" is being passed for some reason, it lets consumers know the other variant types have changed)