### PR TITLE
chore(FormGroup, FormHelperText): remove props

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/formgroup-remove-helpertextProps.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/formgroup-remove-helpertextProps.js
@@ -1,19 +1,29 @@
-const { renameProp } = require('../../helpers');
+const { getPackageImports } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/8810
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'FormGroup',
-    { 
-      helperText: '',
-      helperTextInvalid: '',
-      validated: '',
-      helperTextIcon: '',
-      helperTextInvalidIcon: '',
-      isHelperTextBeforeField: '' 
-    },
-    (node, attribute) =>
-      `${attribute.name.name} prop for ${node.name.name} has been removed. Use FormHelperText, HelperText, and HelperTextItem directly inside children.`
-  ),
+  meta: {},
+  create: function (context) {
+    const formGroupImport =  getPackageImports(context, '@patternfly/react-core')
+    .filter(specifier => specifier.imported.name == 'FormGroup');
+
+    return formGroupImport.length === 0 ? {} : {
+      JSXOpeningElement(node) {
+        if (formGroupImport.map(imp => imp.local.name).includes(node.name.name)) {
+          const helperProps = node.attributes.filter(a => {
+            const attr = a.name?.name;
+            return attr === 'helperText' || attr === 'helperTextInvalid' || attr === 'validated' || attr === 'helperTextIcon' || attr === 'helperTextInvalidIcon' || attr === 'isHelperTextBeforeField'
+          });
+          if (helperProps.length > 0) {
+            helperProps.forEach((attribute) => {
+              context.report({
+                node,
+                message: `${attribute.name?.name} prop for FormGroup has been removed. Use FormHelperText, HelperText, and HelperTextItem directly inside children.`,
+              });
+            });
+          }
+        }
+      }
+    };
+  },
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/formgroup-remove-helpertextProps.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/formgroup-remove-helpertextProps.js
@@ -10,10 +10,8 @@ module.exports = {
     return formGroupImport.length === 0 ? {} : {
       JSXOpeningElement(node) {
         if (formGroupImport.map(imp => imp.local.name).includes(node.name.name)) {
-          const helperProps = node.attributes.filter(a => {
-            const attr = a.name?.name;
-            return attr === 'helperText' || attr === 'helperTextInvalid' || attr === 'validated' || attr === 'helperTextIcon' || attr === 'helperTextInvalidIcon' || attr === 'isHelperTextBeforeField'
-          });
+          const helperPropNames = ['helperText', 'helperTextInvalid', 'validated', 'helperTextIcon', 'helperTextInvalidIcon', 'isHelperTextBeforeField'];
+          const helperProps = node.attributes.filter(a => helperPropNames.includes(a.name.name));
           if (helperProps.length > 0) {
             helperProps.forEach((attribute) => {
               context.report({

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/formgroup-remove-helpertextProps.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/formgroup-remove-helpertextProps.js
@@ -1,0 +1,19 @@
+const { renameProp } = require('../../helpers');
+
+// https://github.com/patternfly/patternfly-react/pull/8810
+module.exports = {
+  meta: { fixable: 'code' },
+  create: renameProp(
+    'FormGroup',
+    { 
+      helperText: '',
+      helperTextInvalid: '',
+      validated: '',
+      helperTextIcon: '',
+      helperTextInvalidIcon: '',
+      isHelperTextBeforeField: '' 
+    },
+    (node, attribute) =>
+      `${attribute.name.name} prop for ${node.name.name} has been removed. Use FormHelperText, HelperText, and HelperTextItem directly inside children.`
+  ),
+};

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/formhelpertext-remove-props.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/formhelpertext-remove-props.js
@@ -1,0 +1,17 @@
+const { renameProp } = require('../../helpers');
+
+// https://github.com/patternfly/patternfly-react/pull/8810
+module.exports = {
+  meta: { fixable: 'code' },
+  create: renameProp(
+    'FormHelperText',
+    { 
+      isError: '',
+      isHidden: '',
+      icon: '',
+      component: ''
+    },
+    (node, attribute) =>
+      `${attribute.name.name} prop for ${node.name.name} has been removed. Use HelperText and HelperTextItem directly in children.`
+  ),
+};

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/formgroup-remove-helpertextProps.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/formgroup-remove-helpertextProps.js
@@ -19,7 +19,7 @@ ruleTester.run("formgroup-remove-helpertextProps", rule, {
   invalid: [
     {
       code: `import { FormGroup } from '@patternfly/react-core'; <FormGroup helperText="Upload a CSV file" helperTextInvalid="Must be a CSV file no larger than 1 KB" validated={isRejected ? 'error' : 'default'} helperTextIcon={<Icon />} helperTextInvalidIcon={<Icon2 />} isHelperTextBeforeField={false} />`,
-      output: `import { FormGroup } from '@patternfly/react-core'; <FormGroup       />`,
+      output: `import { FormGroup } from '@patternfly/react-core'; <FormGroup helperText="Upload a CSV file" helperTextInvalid="Must be a CSV file no larger than 1 KB" validated={isRejected ? 'error' : 'default'} helperTextIcon={<Icon />} helperTextInvalidIcon={<Icon2 />} isHelperTextBeforeField={false} />`,
       errors: [
         {
           message: `helperText prop for FormGroup has been removed. Use FormHelperText, HelperText, and HelperTextItem directly inside children.`,

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/formgroup-remove-helpertextProps.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/formgroup-remove-helpertextProps.js
@@ -1,0 +1,51 @@
+const ruleTester = require("../../ruletester");
+const rule = require("../../../lib/rules/v5/formgroup-remove-helpertextProps");
+
+ruleTester.run("formgroup-remove-helpertextProps", rule, {
+  valid: [
+    {
+      code: `import { FormGroup } from '@patternfly/react-core'; <FormGroup />`,
+    },
+    // No @patternfly/react-core import
+    { code: `<FormGroup 
+        helperText="Upload a CSV file"
+        helperTextInvalid="Must be a CSV file no larger than 1 KB"
+        validated={isRejected ? 'error' : 'default'}
+        helperTextIcon={<Icon />}
+        helperTextInvalidIcon={<Icon2 />}
+        isHelperTextBeforeField={false} 
+      />` },
+  ],
+  invalid: [
+    {
+      code: `import { FormGroup } from '@patternfly/react-core'; <FormGroup helperText="Upload a CSV file" helperTextInvalid="Must be a CSV file no larger than 1 KB" validated={isRejected ? 'error' : 'default'} helperTextIcon={<Icon />} helperTextInvalidIcon={<Icon2 />} isHelperTextBeforeField={false} />`,
+      output: `import { FormGroup } from '@patternfly/react-core'; <FormGroup       />`,
+      errors: [
+        {
+          message: `helperText prop for FormGroup has been removed. Use FormHelperText, HelperText, and HelperTextItem directly inside children.`,
+          type: "JSXOpeningElement",
+        },
+        {
+          message: `helperTextInvalid prop for FormGroup has been removed. Use FormHelperText, HelperText, and HelperTextItem directly inside children.`,
+          type: "JSXOpeningElement",
+        },
+        {
+          message: `validated prop for FormGroup has been removed. Use FormHelperText, HelperText, and HelperTextItem directly inside children.`,
+          type: "JSXOpeningElement",
+        },
+        {
+          message: `helperTextIcon prop for FormGroup has been removed. Use FormHelperText, HelperText, and HelperTextItem directly inside children.`,
+          type: "JSXOpeningElement",
+        },
+        {
+          message: `helperTextInvalidIcon prop for FormGroup has been removed. Use FormHelperText, HelperText, and HelperTextItem directly inside children.`,
+          type: "JSXOpeningElement",
+        },
+        {
+          message: `isHelperTextBeforeField prop for FormGroup has been removed. Use FormHelperText, HelperText, and HelperTextItem directly inside children.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/formhelpertext-remove-props.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/formhelpertext-remove-props.js
@@ -1,0 +1,41 @@
+const ruleTester = require("../../ruletester");
+const rule = require("../../../lib/rules/v5/formhelpertext-remove-props");
+
+ruleTester.run("formhelpertext-remove-props", rule, {
+  valid: [
+    {
+      code: `import { FormHelperText } from '@patternfly/react-core'; <FormHelperText />`,
+    },
+    // No @patternfly/react-core import
+    { code: `<FormHelperText 
+        isError={true}
+        isHidden={false}
+        icon={<Icon />}
+        component="div"
+      />` },
+  ],
+  invalid: [
+    {
+      code: `import { FormHelperText } from '@patternfly/react-core'; <FormHelperText isError={true} isHidden={false} icon={<Icon />} component="div" />`,
+      output: `import { FormHelperText } from '@patternfly/react-core'; <FormHelperText     />`,
+      errors: [
+        {
+          message: `isError prop for FormHelperText has been removed. Use HelperText and HelperTextItem directly in children.`,
+          type: "JSXOpeningElement",
+        },
+        {
+          message: `isHidden prop for FormHelperText has been removed. Use HelperText and HelperTextItem directly in children.`,
+          type: "JSXOpeningElement",
+        },
+        {
+          message: `icon prop for FormHelperText has been removed. Use HelperText and HelperTextItem directly in children.`,
+          type: "JSXOpeningElement",
+        },
+        {
+          message: `component prop for FormHelperText has been removed. Use HelperText and HelperTextItem directly in children.`,
+          type: "JSXOpeningElement",
+        }
+      ],
+    },
+  ],
+});

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -740,6 +740,49 @@ Out:
 <FileUpload  />
 ```
 
+### formgroup-remove-helpertextProps [(#8810)](https://github.com/patternfly/patternfly-react/pull/8810)
+
+We've removed the helper text related props from `FormGroup`. This rule will remove the `helperText`, `helperTextInvalid`, `validated`, `helperTextIcon`, `helperTextInvalidIcon`, and `isHelperTextBeforeField` props if present. The `FormHelperText`, `HelperText`, and `HelperTextItem` components should now be used directly as part of `children` instead of these props.
+
+#### Examples
+
+In:
+
+```jsx
+<FormGroup 
+  helperText="Upload a CSV file" 
+  helperTextInvalid="Must be a CSV file no larger than 1 KB"
+  validated={isRejected ? 'error' : 'default'} 
+  helperTextIcon={<Icon />} 
+  helperTextInvalidIcon={<Icon2 />} 
+  isHelperTextBeforeField={false} 
+/>
+```
+
+Out:
+
+```jsx
+<FormGroup       />
+```
+
+### formhelpertext-remove-props [(#8810)](https://github.com/patternfly/patternfly-react/pull/8810)
+
+We've removed functionality from `FormHelperText` as now the logic will be covered by `HelperText` and `HelperTextItem`. This rule will remove the `isError`, `isHidden`, `icon`, and `component` props if present. The `HelperText` and `HelperTextItem` components should now be used directly as part of `children` instead of these props.
+
+#### Examples
+
+In:
+
+```jsx
+<FormHelperText isError={true} isHidden={false} icon={<Icon />} component="div" />
+```
+
+Out:
+
+```jsx
+<FormHelperText     />
+```
+
 ### hasCheck-prop-rename [(#8403)](https://github.com/patternfly/patternfly-react/pull/8403)
 
 We've renamed the `hasCheck` prop for TreeView, MenuItem, and the Next implementation of SelectOption to `hasCheckbox`.

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -744,27 +744,6 @@ Out:
 
 We've removed the helper text related props from `FormGroup`. This rule will remove the `helperText`, `helperTextInvalid`, `validated`, `helperTextIcon`, `helperTextInvalidIcon`, and `isHelperTextBeforeField` props if present. The `FormHelperText`, `HelperText`, and `HelperTextItem` components should now be used directly as part of `children` instead of these props.
 
-#### Examples
-
-In:
-
-```jsx
-<FormGroup 
-  helperText="Upload a CSV file" 
-  helperTextInvalid="Must be a CSV file no larger than 1 KB"
-  validated={isRejected ? 'error' : 'default'} 
-  helperTextIcon={<Icon />} 
-  helperTextInvalidIcon={<Icon2 />} 
-  isHelperTextBeforeField={false} 
-/>
-```
-
-Out:
-
-```jsx
-<FormGroup       />
-```
-
 ### formhelpertext-remove-props [(#8810)](https://github.com/patternfly/patternfly-react/pull/8810)
 
 We've removed functionality from `FormHelperText` as now the logic will be covered by `HelperText` and `HelperTextItem`. This rule will remove the `isError`, `isHidden`, `icon`, and `component` props if present. The `HelperText` and `HelperTextItem` components should now be used directly as part of `children` instead of these props.

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -742,7 +742,7 @@ Out:
 
 ### formgroup-remove-helpertextProps [(#8810)](https://github.com/patternfly/patternfly-react/pull/8810)
 
-We've removed the helper text related props from `FormGroup`. This rule will remove the `helperText`, `helperTextInvalid`, `validated`, `helperTextIcon`, `helperTextInvalidIcon`, and `isHelperTextBeforeField` props if present. The `FormHelperText`, `HelperText`, and `HelperTextItem` components should now be used directly as part of `children` instead of these props.
+We've removed the helper text related props from `FormGroup`: `helperText`, `helperTextInvalid`, `validated`, `helperTextIcon`, `helperTextInvalidIcon`, and `isHelperTextBeforeField`. The `FormHelperText`, `HelperText`, and `HelperTextItem` components should now be used directly as part of `children` instead of these props. This rule will throw an error but not make any changes. 
 
 ### formhelpertext-remove-props [(#8810)](https://github.com/patternfly/patternfly-react/pull/8810)
 


### PR DESCRIPTION
Removes props and warns about using `HelperText`, `HelperTextItem`, and `FormHelperText`. Had initially tried to insert the replacement node but there are many different translations that could be required based on which properties are present and what the value of the properties are (especially how the `validated` prop would translate into the new structure). I can fiddle with it more if we want to try to build the replacement HelperText block.