### PR TITLE
chore(Menu): rename MenuInput

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/menu-search-rename.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/menu-search-rename.js
@@ -1,0 +1,39 @@
+const { getPackageImports, ensureImports } = require('../../helpers');
+
+// https://github.com/patternfly/patternfly-react/pull/8820
+module.exports = {
+  meta: { fixable: 'code' },
+  create: function(context) { 
+    const imports = getPackageImports(context, '@patternfly/react-core');
+    const menuInputImport = imports.find(imp => imp.imported.name === 'MenuInput');
+
+    return imports.length === 0 || !menuInputImport ? {} : { 
+      ImportDeclaration(node) {
+        ensureImports(context, node, '@patternfly/react-core', ['MenuSearch', 'MenuSearchInput']);
+      },
+      JSXOpeningElement(node) {
+        if (node.name.name === menuInputImport.local.name) {
+          context.report({
+            node,
+            message: "MenuInput has been renamed to MenuSearchInput and MenuSearch has been added as a wrapper.",
+            fix(fixer) {
+              const fixes = [];
+
+              fixes.push(
+                fixer.insertTextBefore(node, "<MenuSearch>"),
+                fixer.replaceText(node.name, "MenuSearchInput"),
+                fixer.insertTextAfter(node.parent, "</MenuSearch>")
+              );
+
+              if(node?.parent?.closingElement) {
+                fixes.push(fixer.replaceText(node.parent.closingElement.name, "MenuSearchInput"));
+              }
+              
+              return fixes;
+            }
+          });
+        }
+      }
+    };
+  }
+};

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/menu-search-rename.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/menu-search-rename.js
@@ -9,7 +9,22 @@ module.exports = {
 
     return imports.length === 0 || !menuInputImport ? {} : { 
       ImportDeclaration(node) {
-        ensureImports(context, node, '@patternfly/react-core', ['MenuSearch', 'MenuSearchInput']);
+        if(menuInputImport) {
+          context.report({
+            node,
+            message: 'add missing imports MenuSearch, MenuSearchInput from @patternfly/react-core',
+            fix(fixer) {
+              const fixes = [];
+              
+              fixes.push(
+                fixer.replaceText(menuInputImport, 'MenuSearch'),
+                fixer.insertTextAfter(node.specifiers[node.specifiers.length - 1], `, MenuSearchInput`)
+              );
+              
+              return fixes;
+            }
+          })
+        }
       },
       JSXOpeningElement(node) {
         if (node.name.name === menuInputImport.local.name) {

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/menu-search-rename.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/menu-search-rename.js
@@ -1,0 +1,42 @@
+const ruleTester = require("../../ruletester");
+const rule = require("../../../lib/rules/v5/menu-search-rename");
+
+ruleTester.run("menu-search-rename", rule, {
+  valid: [
+    {
+      code: `import { MenuSearchInput, MenuSearch } from '@patternfly/react-core'; <MenuSearch><MenuSearchInput /></MenuSearch>`,
+    },
+    // No @patternfly/react-core import
+    { code: `<MenuInput />` },
+  ],
+  invalid: [
+    {
+      code: `import { MenuInput } from '@patternfly/react-core'; <MenuInput><div /></MenuInput>`,
+      output: `import { MenuInput, MenuSearch, MenuSearchInput } from '@patternfly/react-core'; <MenuSearch><MenuSearchInput><div /></MenuSearchInput></MenuSearch>`,
+      errors: [
+        {
+          message: 'add missing imports MenuSearch, MenuSearchInput from @patternfly/react-core',
+          type: "ImportDeclaration"
+        },
+        {
+          message: `MenuInput has been renamed to MenuSearchInput and MenuSearch has been added as a wrapper.`,
+          type: "JSXOpeningElement",
+        }
+      ],
+    },
+    {
+      code: `import { MenuInput } from '@patternfly/react-core'; <MenuInput />`,
+      output: `import { MenuInput, MenuSearch, MenuSearchInput } from '@patternfly/react-core'; <MenuSearch><MenuSearchInput /></MenuSearch>`,
+      errors: [
+        {
+          message: 'add missing imports MenuSearch, MenuSearchInput from @patternfly/react-core',
+          type: "ImportDeclaration"
+        },
+        {
+          message: `MenuInput has been renamed to MenuSearchInput and MenuSearch has been added as a wrapper.`,
+          type: "JSXOpeningElement",
+        }
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/menu-search-rename.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/menu-search-rename.js
@@ -12,7 +12,7 @@ ruleTester.run("menu-search-rename", rule, {
   invalid: [
     {
       code: `import { MenuInput } from '@patternfly/react-core'; <MenuInput><div /></MenuInput>`,
-      output: `import { MenuInput, MenuSearch, MenuSearchInput } from '@patternfly/react-core'; <MenuSearch><MenuSearchInput><div /></MenuSearchInput></MenuSearch>`,
+      output: `import { MenuSearch, MenuSearchInput } from '@patternfly/react-core'; <MenuSearch><MenuSearchInput><div /></MenuSearchInput></MenuSearch>`,
       errors: [
         {
           message: 'add missing imports MenuSearch, MenuSearchInput from @patternfly/react-core',
@@ -26,7 +26,7 @@ ruleTester.run("menu-search-rename", rule, {
     },
     {
       code: `import { MenuInput } from '@patternfly/react-core'; <MenuInput />`,
-      output: `import { MenuInput, MenuSearch, MenuSearchInput } from '@patternfly/react-core'; <MenuSearch><MenuSearchInput /></MenuSearch>`,
+      output: `import { MenuSearch, MenuSearchInput } from '@patternfly/react-core'; <MenuSearch><MenuSearchInput /></MenuSearch>`,
       errors: [
         {
           message: 'add missing imports MenuSearch, MenuSearchInput from @patternfly/react-core',

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -874,6 +874,22 @@ Out:
 
 We've update the `aria-label` prop on MenuItemAction, making it required instead of optional.
 
+### menu-search-rename [(#8820)](https://github.com/patternfly/patternfly-react/pull/8820)
+
+`MenuInput` has been renamed to `MenuSearchInput` and `MenuSearch` has been added as a wrapper.
+
+In:
+
+```jsx
+  <MenuInput><SearchInput /></MenuInput>
+```
+
+Out:
+
+```jsx
+    <MenuSearch><MenuSearchInput><SearchInput /></MenuSearchInput></MenuSearch>
+```
+
 ### nav-warn-flyouts-now-inline [(#8628)](https://github.com/patternfly/patternfly-react/pull/8628)
 
 The placement Nav flyouts in the DOM has been changed, if you have Nav elements with flyouts you may need to update some selectors or snapshots in your test suites. This rule will raise a warning, but will not make any changes.


### PR DESCRIPTION
To `MenuSearchInput` and add `MenuSearch` as a wrapper.

Codemod for https://github.com/patternfly/patternfly-react/issues/8187