### PR TITLE
chore(Table): refine ActionsColumn warning

### DIFF
--- a/packages/eslint-plugin-pf-codemods/index.js
+++ b/packages/eslint-plugin-pf-codemods/index.js
@@ -29,6 +29,7 @@ const warningRules = [
   "overflowMenu-warn-updated-dropdownItem",
   "popover-warn-appendTo-default",
   "react-dropzone-warn-upgrade",
+  "table-warn-actionsColumn",
   "table-warn-thExpandType",
   "tabs-warn-children-type-changed",
   "wizard-warn-button-order",

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/table-warn-actionsColumn.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/table-warn-actionsColumn.js
@@ -29,7 +29,7 @@ module.exports = {
         if (tableImport && (dropdownToggleImport || actionsColumnImport)) {
           context.report({
             node,
-            message: "The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.",
+            message: "The ActionsColumn within Table now uses our new implementation of Dropdown. The action toggle should now pass a MenuToggle rather than the deprecated DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.",
           });
         }
       },

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/table-warn-actionsColumn.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/table-warn-actionsColumn.js
@@ -6,8 +6,10 @@ module.exports = {
     return {
       ImportDeclaration(node) {
         const coreImports = getPackageImports(context, '@patternfly/react-core');
+        const deprecatedImports = getPackageImports(context, '@patternfly/react-core/deprecated');
         const tableImports = getPackageImports(context, '@patternfly/react-table');
-        const imports = [...coreImports, ...tableImports];
+        const deprecatedTableImports = getPackageImports(context, '@patternfly/react-table/deprecated');
+        const imports = [...coreImports, ...tableImports, ...deprecatedImports, ...deprecatedTableImports];
 
         const tableImport = imports.find(
           (specifier) =>

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/table-warn-actionsColumn.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/table-warn-actionsColumn.js
@@ -1,18 +1,33 @@
+const { getPackageImports } = require('../../helpers');
+
 // https://github.com/patternfly/patternfly-react/pull/8629
 module.exports = {
   create: function (context) {
     return {
-      ImportDeclaration(node) {
-        const TableImport = node.specifiers.find(
+      Program(node) {
+        const coreImports = getPackageImports(context, '@patternfly/react-core');
+        const tableImports = getPackageImports(context, '@patternfly/react-table');
+        const imports = [...coreImports, ...tableImports];
+
+        const tableImport = imports.find(
           (specifier) =>
-            node.source.value === "@patternfly/react-table" &&
             (specifier.imported.name === "Table" || specifier.imported.name === "TableComposable")
         );
 
-        if (TableImport) {
+        const dropdownToggleImport = imports.find(
+          (specifier) =>
+            (specifier.imported.name === "DropdownToggle")
+        );
+
+        const actionsColumnImport = imports.find(
+          (specifier) =>
+            (specifier.imported.name === "ActionsColumn")
+        );
+
+        if (tableImport && (dropdownToggleImport || actionsColumnImport)) {
           context.report({
             node,
-            message: "The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the new popperProps property.",
+            message: "The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.",
           });
         }
       },

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/table-warn-actionsColumn.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/table-warn-actionsColumn.js
@@ -4,7 +4,7 @@ const { getPackageImports } = require('../../helpers');
 module.exports = {
   create: function (context) {
     return {
-      Program(node) {
+      ImportDeclaration(node) {
         const coreImports = getPackageImports(context, '@patternfly/react-core');
         const tableImports = getPackageImports(context, '@patternfly/react-table');
         const imports = [...coreImports, ...tableImports];

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/table-warn-actionsColumn.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/table-warn-actionsColumn.js
@@ -4,6 +4,12 @@ const rule = require('../../../lib/rules/v5/table-warn-actionsColumn');
 ruleTester.run("table-warn-actionsColumn", rule, {
   valid: [
     {
+      code: `import { Table } from '@patternfly/react-table'; <Table />`,
+    },
+    {
+      code: `import { TableComposable } from '@patternfly/react-table'; <TableComposable />`,
+    },
+    {
       code: `<Table />`,
     },
     {
@@ -12,19 +18,19 @@ ruleTester.run("table-warn-actionsColumn", rule, {
   ],
   invalid: [
     {
-      code:   `import { Table } from '@patternfly/react-table';`,
-      output: `import { Table } from '@patternfly/react-table';`,
+      code:   `import { Table } from '@patternfly/react-table'; import { DropdownToggle } from '@patternfly/react-core';`,
+      output: `import { Table } from '@patternfly/react-table'; import { DropdownToggle } from '@patternfly/react-core';`,
       errors: [{
-        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the new popperProps property.`,
-        type: "ImportDeclaration",
+        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
+        type: "Program",
       }]
     },
     {
-      code:   `import { TableComposable } from '@patternfly/react-table';`,
-      output: `import { TableComposable } from '@patternfly/react-table';`,
+      code:   `import { TableComposable, ActionsColumn } from '@patternfly/react-table';`,
+      output: `import { TableComposable, ActionsColumn } from '@patternfly/react-table';`,
       errors: [{
-        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the new popperProps property.`,
-        type: "ImportDeclaration",
+        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
+        type: "Program",
       }]
     },
   ]

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/table-warn-actionsColumn.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/table-warn-actionsColumn.js
@@ -20,18 +20,24 @@ ruleTester.run("table-warn-actionsColumn", rule, {
     {
       code:   `import { Table } from '@patternfly/react-table'; import { DropdownToggle } from '@patternfly/react-core';`,
       output: `import { Table } from '@patternfly/react-table'; import { DropdownToggle } from '@patternfly/react-core';`,
-      errors: [{
+      errors: [
+        {
         message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
-        type: "Program",
-      }]
+        type: "ImportDeclaration",
+        },
+        {
+        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
+        type: "ImportDeclaration",
+        }
+      ]
     },
     {
       code:   `import { TableComposable, ActionsColumn } from '@patternfly/react-table';`,
       output: `import { TableComposable, ActionsColumn } from '@patternfly/react-table';`,
       errors: [{
         message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
-        type: "Program",
-      }]
+        type: "ImportDeclaration",
+        }]
     },
   ]
 });

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/table-warn-actionsColumn.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/table-warn-actionsColumn.js
@@ -39,5 +39,33 @@ ruleTester.run("table-warn-actionsColumn", rule, {
         type: "ImportDeclaration",
         }]
     },
+    {
+      code:   `import { Table } from '@patternfly/react-table'; import { DropdownToggle as DropdownToggleDeprecated } from '@patternfly/react-core/deprecated';`,
+      output: `import { Table } from '@patternfly/react-table'; import { DropdownToggle as DropdownToggleDeprecated } from '@patternfly/react-core/deprecated';`,
+      errors: [
+        {
+        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
+        type: "ImportDeclaration",
+        },
+        {
+        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
+        type: "ImportDeclaration",
+        }
+      ]
+    },
+    {
+      code:   `import { Table as TableDeprecated } from '@patternfly/react-table/deprecated'; import { DropdownToggle as DropdownToggleDeprecated } from '@patternfly/react-core/deprecated';`,
+      output: `import { Table as TableDeprecated } from '@patternfly/react-table/deprecated'; import { DropdownToggle as DropdownToggleDeprecated } from '@patternfly/react-core/deprecated';`,
+      errors: [
+        {
+        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
+        type: "ImportDeclaration",
+        },
+        {
+        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
+        type: "ImportDeclaration",
+        }
+      ]
+    },
   ]
 });

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/table-warn-actionsColumn.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/table-warn-actionsColumn.js
@@ -22,11 +22,11 @@ ruleTester.run("table-warn-actionsColumn", rule, {
       output: `import { Table } from '@patternfly/react-table'; import { DropdownToggle } from '@patternfly/react-core';`,
       errors: [
         {
-        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
+        message: `The ActionsColumn within Table now uses our new implementation of Dropdown. The action toggle should now pass a MenuToggle rather than the deprecated DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
         type: "ImportDeclaration",
         },
         {
-        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
+        message: `The ActionsColumn within Table now uses our new implementation of Dropdown. The action toggle should now pass a MenuToggle rather than the deprecated DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
         type: "ImportDeclaration",
         }
       ]
@@ -35,7 +35,7 @@ ruleTester.run("table-warn-actionsColumn", rule, {
       code:   `import { TableComposable, ActionsColumn } from '@patternfly/react-table';`,
       output: `import { TableComposable, ActionsColumn } from '@patternfly/react-table';`,
       errors: [{
-        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
+        message: `The ActionsColumn within Table now uses our new implementation of Dropdown. The action toggle should now pass a MenuToggle rather than the deprecated DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
         type: "ImportDeclaration",
         }]
     },
@@ -44,11 +44,11 @@ ruleTester.run("table-warn-actionsColumn", rule, {
       output: `import { Table } from '@patternfly/react-table'; import { DropdownToggle as DropdownToggleDeprecated } from '@patternfly/react-core/deprecated';`,
       errors: [
         {
-        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
+        message: `The ActionsColumn within Table now uses our new implementation of Dropdown. The action toggle should now pass a MenuToggle rather than the deprecated DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
         type: "ImportDeclaration",
         },
         {
-        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
+        message: `The ActionsColumn within Table now uses our new implementation of Dropdown. The action toggle should now pass a MenuToggle rather than the deprecated DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
         type: "ImportDeclaration",
         }
       ]
@@ -58,11 +58,11 @@ ruleTester.run("table-warn-actionsColumn", rule, {
       output: `import { Table as TableDeprecated } from '@patternfly/react-table/deprecated'; import { DropdownToggle as DropdownToggleDeprecated } from '@patternfly/react-core/deprecated';`,
       errors: [
         {
-        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
+        message: `The ActionsColumn within Table now uses our new implementation of Dropdown. The action toggle should now pass a MenuToggle rather than the deprecated DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
         type: "ImportDeclaration",
         },
         {
-        message: `The ActionsColumn now uses the Next version of Dropdown. The action toggle should now pass a MenuToggle rather than a DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
+        message: `The ActionsColumn within Table now uses our new implementation of Dropdown. The action toggle should now pass a MenuToggle rather than the deprecated DropdownToggle, and direction and position properties are now passed under the ActionsColumn new popperProps property.`,
         type: "ImportDeclaration",
         }
       ]

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -1252,7 +1252,7 @@ Out:
 
 ### table-warn-actionsColumn [(#8629)](https://github.com/patternfly/patternfly-react/pull/8629)
 
-Table and TableComposable's `ActionsColumn` has been updated to use the newer 'next' version of Dropdown. The toggle passed to the actions column should now be a `MenuToggle` instead of a `DropdownToggle`. The `dropdownPosition`, `dropdownDirection` and `menuAppendTo` properties are removed and `Popper` properties can be passed in using `popperProps` instead (via `direction`, `position`, `appendTo`, etc.).
+Table and TableComposable's `ActionsColumn` has been updated to use our new implementation of Dropdown. The toggle passed to the actions column should now be a `MenuToggle` instead of the deprecated `DropdownToggle`. The `dropdownPosition`, `dropdownDirection` and `menuAppendTo` properties are removed and `Popper` properties can be passed in using `popperProps` instead (via `direction`, `position`, `appendTo`, etc.).
 
 ### table-warn-thExpandType [(#8634)](https://github.com/patternfly/patternfly-react/pull/8634)
 


### PR DESCRIPTION
Now will issue a warning, and only if both the Table import and ActionsColumn/DropdownToggle are also imported.