### PR TITLE
feat(Card): updated CardHeader API

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/banner-update-variant.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/banner-update-variant.js
@@ -1,5 +1,6 @@
 const { getPackageImports } = require("../../helpers");
 
+// https://github.com/patternfly/patternfly-react/issues/8204
 module.exports = {
   meta: { fixable: "code" },
   create: function (context) {

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/cardHeader-update-api.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/cardHeader-update-api.js
@@ -80,59 +80,59 @@ module.exports = {
             const cardHeaderMain = findChildComponent("CardHeaderMain");
             const cardActions = findChildComponent("CardActions");
 
-            if (cardHeaderMain || cardActions) {
-              let messagePrefix = [
-                cardHeaderMain?.openingElement?.name?.name,
-                cardActions?.openingElement?.name?.name,
-              ]
-                .filter((componentName) => componentName)
-                .join(" and ");
-
-              context.report({
-                node,
-                message: `${messagePrefix} ${
-                  messagePrefix.includes("and") ? "are" : "is"
-                } now rendered internally within CardHeader and should be passed to CardHeader instead.`,
-                fix(fixer) {
-                  const fixes = [];
-
-                  if (cardHeaderMain) {
-                    const cardHeaderMainContent =
-                      getChildComponentContent(cardHeaderMain);
-
-                    fixes.push(
-                      fixer.replaceText(cardHeaderMain, cardHeaderMainContent)
-                    );
-                  }
-
-                  if (cardActions) {
-                    const cardActionProps =
-                      cardActions.openingElement.attributes;
-                    const existingClassProp = cardActionProps.find(
-                      (prop) => prop.name.name === "className"
-                    );
-                    const cardActionsContent =
-                      getChildComponentContent(cardActions).trim();
-                    const newActionsPropValue = `{ actions: <>${cardActionsContent}</>, hasNoOffset: ${cardActionProps.some(
-                      (prop) => prop.name.name === "hasNoOffset"
-                    )}, className: ${
-                      existingClassProp
-                        ? `"${existingClassProp.value.value}"`
-                        : undefined
-                    }}`;
-
-                    fixes.push(
-                      fixer.insertTextAfter(
-                        node.openingElement.name,
-                        ` actions={${newActionsPropValue}} `
-                      ),
-                      fixer.remove(cardActions)
-                    );
-                  }
-                  return fixes;
-                },
-              });
+            if (!cardHeaderMain && !cardActions) {
+              return;
             }
+            let messagePrefix = [
+              cardHeaderMain?.openingElement?.name?.name,
+              cardActions?.openingElement?.name?.name,
+            ]
+              .filter((componentName) => componentName)
+              .join(" and ");
+
+            context.report({
+              node,
+              message: `${messagePrefix} ${
+                messagePrefix.includes("and") ? "are" : "is"
+              } now rendered internally within CardHeader and should be passed to CardHeader instead.`,
+              fix(fixer) {
+                const fixes = [];
+
+                if (cardHeaderMain) {
+                  const cardHeaderMainContent =
+                    getChildComponentContent(cardHeaderMain);
+
+                  fixes.push(
+                    fixer.replaceText(cardHeaderMain, cardHeaderMainContent)
+                  );
+                }
+
+                if (cardActions) {
+                  const cardActionProps = cardActions.openingElement.attributes;
+                  const existingClassProp = cardActionProps.find(
+                    (prop) => prop.name.name === "className"
+                  );
+                  const cardActionsContent =
+                    getChildComponentContent(cardActions).trim();
+                  const newActionsPropValue = `{ actions: <>${cardActionsContent}</>, hasNoOffset: ${cardActionProps.some(
+                    (prop) => prop.name.name === "hasNoOffset"
+                  )}, className: ${
+                    existingClassProp
+                      ? `"${existingClassProp.value.value}"`
+                      : undefined
+                  }}`;
+
+                  fixes.push(
+                    fixer.insertTextAfter(
+                      node.openingElement.name,
+                      ` actions={${newActionsPropValue}} `
+                    ),
+                    fixer.remove(cardActions)
+                  );
+                }
+                return fixes;
+              },
+            });
           },
         };
   },

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/cardHeader-update-api.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/cardHeader-update-api.js
@@ -1,0 +1,133 @@
+const { getPackageImports } = require("../../helpers");
+
+// https://github.com/patternfly/patternfly-react/pull/8759
+module.exports = {
+  meta: { fixable: "code" },
+  create: function (context) {
+    const cardImports = getPackageImports(
+      context,
+      "@patternfly/react-core"
+    ).filter((specifier) =>
+      ["CardHeaderMain", "CardActions", "CardHeader"].includes(
+        specifier.imported.name
+      )
+    );
+
+    return !cardImports.length
+      ? {}
+      : {
+          ImportDeclaration(node) {
+            if (
+              node.source.value !== "@patternfly/react-core" ||
+              !node.specifiers.filter((specifier) =>
+                cardImports
+                  .map((imp) => imp.imported.name)
+                  .includes(specifier?.imported?.name)
+              ).length
+            ) {
+              return;
+            }
+
+            node.specifiers
+              .filter((specifier) =>
+                ["CardHeaderMain", "CardActions"].includes(
+                  specifier.imported.name
+                )
+              )
+              .forEach((specifier) => {
+                const hasCommaAfter =
+                  context.getSourceCode().getTokenAfter(specifier).value ===
+                  ",";
+
+                context.report({
+                  node,
+                  message: `${specifier.imported.name} is no longer exported.`,
+                  fix(fixer) {
+                    return hasCommaAfter
+                      ? fixer.removeRange([
+                          specifier.range[0],
+                          specifier.range[1] + 1,
+                        ])
+                      : fixer.remove(specifier);
+                  },
+                });
+              });
+          },
+          JSXElement(node) {
+            if (node.openingElement.name.name !== "CardHeader") {
+              return;
+            }
+
+            const findChildComponent = (childName) =>
+              node.children.find(
+                (child) =>
+                  child.type === "JSXElement" &&
+                  child.openingElement.name.name === childName
+              );
+
+            const getChildComponentContent = (childComponent) => {
+              const childRegex = new RegExp(
+                `<\/?${childComponent.openingElement.name.name}(.*?)>`,
+                "g"
+              );
+
+              return context
+                .getSourceCode()
+                .getText(childComponent)
+                .replace(childRegex, "");
+            };
+
+            const cardHeaderMain = findChildComponent("CardHeaderMain");
+            const cardActions = findChildComponent("CardActions");
+
+            if (cardHeaderMain) {
+              context.report({
+                node,
+                message:
+                  "CardHeaderMain is now rendered internally within CardHeader. Any CardHeaderMain content should instead be passed as children to CardHeader.",
+                fix(fixer) {
+                  const cardHeaderMainContent =
+                    getChildComponentContent(cardHeaderMain);
+                  return fixer.replaceText(
+                    cardHeaderMain,
+                    cardHeaderMainContent
+                  );
+                },
+              });
+            }
+
+            if (cardActions) {
+              context.report({
+                node,
+                message: `CardActions is now rendered internally within CardHeader. Any CardActions props should instead be passed as a CardHeaderActionsObject to CardHeader's "actions" prop.`,
+                fix(fixer) {
+                  const cardActionProps = cardActions.openingElement.attributes;
+                  const existingClassProp = cardActionProps.find(
+                    (prop) => prop.name.name === "className"
+                  );
+                  const cardActionsContent = getChildComponentContent(
+                    cardActions
+                  ).replace(/\s*/g, "");
+                  const newActionsPropValue = `{ actions: <>${cardActionsContent}</>, hasNoOffset: ${cardActionProps.some(
+                    (prop) => prop.name.name === "hasNoOffset"
+                  )}, className: ${
+                    existingClassProp
+                      ? `"${existingClassProp.value.value}"`
+                      : undefined
+                  }
+                  }`;
+
+                  return [
+                    fixer.insertTextAfter(
+                      node.openingElement.attributes.pop(),
+                      ` actions={${newActionsPropValue}}`
+                    ),
+                    fixer.remove(cardActions),
+                  ];
+                },
+              });
+            }
+          },
+        };
+  },
+};

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/cardHeader-update-api.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/cardHeader-update-api.js
@@ -14,7 +14,7 @@ ruleTester.run("cardHeader-update-api", rule, {
   invalid: [
     {
       code: `import { CardHeader, CardHeaderMain } from '@patternfly/react-core'; <CardHeader><CardHeaderMain>Header content</CardHeaderMain></CardHeader>`,
-      output: `import { CardHeader,  } from '@patternfly/react-core'; <CardHeader>Header content</CardHeader>`,
+      output: `import { CardHeader } from '@patternfly/react-core'; <CardHeader>Header content</CardHeader>`,
       errors: [
         {
           message: `CardHeaderMain is no longer exported.`,
@@ -28,7 +28,7 @@ ruleTester.run("cardHeader-update-api", rule, {
     },
     {
       code: `import { CardHeader, CardActions } from '@patternfly/react-core'; <CardHeader><CardActions hasNoOffset className="test"><Action /></CardActions></CardHeader>`,
-      output: `import { CardHeader,  } from '@patternfly/react-core'; <CardHeader actions={{ actions: <><Action /></>, hasNoOffset: true, className: "test"}} ></CardHeader>`,
+      output: `import { CardHeader } from '@patternfly/react-core'; <CardHeader actions={{ actions: <><Action /></>, hasNoOffset: true, className: "test"}} ></CardHeader>`,
       errors: [
         {
           message: `CardActions is no longer exported.`,
@@ -42,14 +42,10 @@ ruleTester.run("cardHeader-update-api", rule, {
     },
     {
       code: `import { CardHeader, CardHeaderMain, CardActions } from '@patternfly/react-core'; <CardHeader><CardHeaderMain>Header content</CardHeaderMain><CardActions hasNoOffset className="test"><Action /></CardActions></CardHeader>`,
-      output: `import { CardHeader,   } from '@patternfly/react-core'; <CardHeader actions={{ actions: <><Action /></>, hasNoOffset: true, className: "test"}} >Header content</CardHeader>`,
+      output: `import { CardHeader } from '@patternfly/react-core'; <CardHeader actions={{ actions: <><Action /></>, hasNoOffset: true, className: "test"}} >Header content</CardHeader>`,
       errors: [
         {
-          message: `CardHeaderMain is no longer exported.`,
-          type: "ImportDeclaration",
-        },
-        {
-          message: `CardActions is no longer exported.`,
+          message: `CardHeaderMain and CardActions are no longer exported.`,
           type: "ImportDeclaration",
         },
         {

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/cardHeader-update-api.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/cardHeader-update-api.js
@@ -21,21 +21,39 @@ ruleTester.run("cardHeader-update-api", rule, {
           type: "ImportDeclaration",
         },
         {
-          message: `CardHeaderMain is now rendered internally within CardHeader. Any CardHeaderMain content should instead be passed as children to CardHeader.`,
+          message: `CardHeaderMain is now rendered internally within CardHeader and should be passed to CardHeader instead.`,
           type: "JSXElement",
         },
       ],
     },
     {
       code: `import { CardHeader, CardActions } from '@patternfly/react-core'; <CardHeader><CardActions hasNoOffset className="test"><Action /></CardActions></CardHeader>`,
-      output: `import { CardHeader,  } from '@patternfly/react-core'; <CardHeader actions={{ actions: <><Action /></>, hasNoOffset: true, className: "test" }}></CardHeader>`,
+      output: `import { CardHeader,  } from '@patternfly/react-core'; <CardHeader actions={{ actions: <><Action /></>, hasNoOffset: true, className: "test"}} ></CardHeader>`,
       errors: [
         {
           message: `CardActions is no longer exported.`,
           type: "ImportDeclaration",
         },
         {
-          message: `CardActions is now rendered internally within CardHeader. Any CardActions props should instead be passed as a CardHeaderActionsObject to CardHeader's "actions" prop.`,
+          message: `CardActions is now rendered internally within CardHeader and should be passed to CardHeader instead.`,
+          type: "JSXElement",
+        },
+      ],
+    },
+    {
+      code: `import { CardHeader, CardHeaderMain, CardActions } from '@patternfly/react-core'; <CardHeader><CardHeaderMain>Header content</CardHeaderMain><CardActions hasNoOffset className="test"><Action /></CardActions></CardHeader>`,
+      output: `import { CardHeader,   } from '@patternfly/react-core'; <CardHeader actions={{ actions: <><Action /></>, hasNoOffset: true, className: "test"}} >Header content</CardHeader>`,
+      errors: [
+        {
+          message: `CardHeaderMain is no longer exported.`,
+          type: "ImportDeclaration",
+        },
+        {
+          message: `CardActions is no longer exported.`,
+          type: "ImportDeclaration",
+        },
+        {
+          message: `CardHeaderMain and CardActions are now rendered internally within CardHeader and should be passed to CardHeader instead.`,
           type: "JSXElement",
         },
       ],

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/cardHeader-update-api.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/cardHeader-update-api.js
@@ -1,0 +1,44 @@
+const ruleTester = require("../../ruletester");
+const rule = require("../../../lib/rules/v5/cardHeader-update-api");
+
+ruleTester.run("cardHeader-update-api", rule, {
+  valid: [
+    {
+      code: `import { CardHeader } from '@patternfly/react-core'; <CardHeader actions={}>Header content</CardHeader>`,
+    },
+    {
+      // No @patternfly/react-core import
+      code: `<CardHeader><CardHeaderMain /><CardActions /></CardHeader>`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import { CardHeader, CardHeaderMain } from '@patternfly/react-core'; <CardHeader><CardHeaderMain>Header content</CardHeaderMain></CardHeader>`,
+      output: `import { CardHeader,  } from '@patternfly/react-core'; <CardHeader>Header content</CardHeader>`,
+      errors: [
+        {
+          message: `CardHeaderMain is no longer exported.`,
+          type: "ImportDeclaration",
+        },
+        {
+          message: `CardHeaderMain is now rendered internally within CardHeader. Any CardHeaderMain content should instead be passed as children to CardHeader.`,
+          type: "JSXElement",
+        },
+      ],
+    },
+    {
+      code: `import { CardHeader, CardActions } from '@patternfly/react-core'; <CardHeader><CardActions hasNoOffset className="test"><Action /></CardActions></CardHeader>`,
+      output: `import { CardHeader,  } from '@patternfly/react-core'; <CardHeader actions={{ actions: <><Action /></>, hasNoOffset: true, className: "test" }}></CardHeader>`,
+      errors: [
+        {
+          message: `CardActions is no longer exported.`,
+          type: "ImportDeclaration",
+        },
+        {
+          message: `CardActions is now rendered internally within CardHeader. Any CardActions props should instead be passed as a CardHeaderActionsObject to CardHeader's "actions" prop.`,
+          type: "JSXElement",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -272,6 +272,30 @@ function handler2(_event, id) {};
 <Card onSelectableInputChange={handler2}>
 ```
 
+### cardHeader-update-api [(#8759)](https://github.com/patternfly/patternfly-react/pull/8759)
+
+CardHeaderMain and CardActions are no longer exported from PatternFly, and are instead rendered internally within the CardHeader sub-component. Any CardHeaderMain content and CardActions content or props should be passed directly to CardHeader instead.
+
+#### Examples
+
+In:
+
+```jsx
+<CardHeader>
+  <CardHeaderMain>Header content</CardHeaderMain>
+  <CardActions className="test" hasNoOffset><Button>Card action</Button></CardActions>
+</CardHeader>
+```
+
+Out:
+
+```jsx
+<CardHeader actions={{ actions: <><Button>Card action</Button></>, hasNoOffset: true, className: "test"}} >
+  Header content
+  
+</CardHeader>
+```
+
 ### chart-getResizeObserver [(#8533)](https://github.com/patternfly/patternfly-react/pull/8533)
 
 We've removed the `getResizeObserver` function from react-charts in favor of react-core's `getResizeObserver`. This helper function now has a third parameter, `useRequestAnimationFrame`, and allows a single function to be maintained going forward.

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -17,6 +17,9 @@ import {
   Button,
   CalendarMonth,
   Card,
+  CardActions,
+  CardHeader,
+  CardHeaderMain,
   Checkbox,
   ClipboardCopy,
   DataList,
@@ -78,6 +81,10 @@ const newTheme = getCustomTheme("1", "2", "3");
   <Button isSmall />
   <CalendarMonth onChange={date => handleChange(date)} onMonthChange={(newDate, evt) => handleMonthChange(newDate, evt)} />
   <Card onSelectableInputChange={(label, _ev) => handler(label)} />
+  <CardHeader>
+    <CardHeaderMain>Header content</CardHeaderMain>
+    <CardActions className="test" hasNoOffset><Button>Card action</Button></CardActions>
+  </CardHeader>
   <Chart themeVariant />
   <Checkbox onChange={(checked, e) => handleCheck(check, e)} />
   <ClipboardCopy onChange={(foo) => handleChange(foo)} />


### PR DESCRIPTION
Closes #274 

Feel like the error message(s) could be improved a bit... Was considering explaining how to pass stuff for CardHeaderMain and CardActions, but that might be a bit too verbose:

'CardHeaderMain and CardActions are now rendered internally within CardHeader. CardHeaderMain content should be passed directly as children to CardHeader. CardActions props and content should be passed as a CardHeaderActionsObject to CardHeader's "actions" prop.'