### PR TITLE
feat(ApplicationLauncher): update to deprecated path

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/helpers.js
+++ b/packages/eslint-plugin-pf-codemods/lib/helpers.js
@@ -34,7 +34,6 @@ function moveSpecifiers(
       existingToPackageImportDeclaration?.specifiers?.map((specifier) =>
         src.getText(specifier)
       ) || [];
-
     return {
       ImportDeclaration(node) {
         const [newToPackageSpecifiers, fromPackageSpecifiers] =
@@ -103,9 +102,9 @@ function moveSpecifiers(
         });
       },
       JSXElement(node) {
+        if (!aliasSuffix) return;
         // Fixer for importsToMove objects with "component" type
         if (
-          aliasSuffix &&
           importSpecifiersToMove.some(
             (imp) =>
               imp.local.name === node.openingElement.name.name &&
@@ -150,7 +149,7 @@ function moveSpecifiers(
             }
           }
         );
-        if (aliasSuffix && existingPropsToUpdate.length) {
+        if (existingPropsToUpdate.length) {
           existingPropsToUpdate.forEach((propToUpdate) => {
             const currentPropToUpdate =
               propToUpdate.value?.expression?.object ||

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/applicationLauncher-deprecated.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/applicationLauncher-deprecated.js
@@ -1,0 +1,32 @@
+// https://github.com/patternfly/patternfly-react/pull/8836
+const { moveSpecifiers } = require("../../helpers");
+
+const importsToMove = [
+  { name: "ApplicationLauncherText", type: "component" },
+  { name: "ApplicationLauncherTextProps", type: "props" },
+  { name: "ApplicationLauncherSeparator", type: "component" },
+  { name: "ApplicationLauncherItemContext", type: "context" },
+  { name: "ApplicationLauncherItemProps", type: "props" },
+  { name: "ApplicationLauncherItem", type: "component" },
+  { name: "ApplicationLauncherIconProps", type: "props" },
+  { name: "ApplicationLauncherIcon", type: "component" },
+  { name: "ApplicationLauncherGroup", type: "component" },
+  { name: "ApplicationLauncherContext", type: "context" },
+  { name: "ApplicationLauncherContentProps", type: "props" },
+  { name: "ApplicationLauncherContent", type: "component" },
+  { name: "ApplicationLauncherProps", type: "props" },
+  { name: "ApplicationLauncher", type: "component" },
+];
+const fromPackage = "@patternfly/react-core";
+const toPackage = "@patternfly/react-core/deprecated";
+const messageAfterImportNameChange =
+  "been deprecated. Running the fix flag will update your imports to our deprecated package, but we suggest using our new Dropdown or Select implementation.";
+module.exports = {
+  meta: { fixable: "code" },
+  create: moveSpecifiers(
+    importsToMove,
+    fromPackage,
+    toPackage,
+    messageAfterImportNameChange
+  ),
+};

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/applicationLauncher-deprecated.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/applicationLauncher-deprecated.js
@@ -1,0 +1,63 @@
+const ruleTester = require("../../ruletester");
+const rule = require("../../../lib/rules/v5/applicationLauncher-deprecated");
+
+const importsToMove = [
+  "ApplicationLauncherText",
+  "ApplicationLauncherTextProps",
+  "ApplicationLauncherSeparator",
+  "ApplicationLauncherItemContext",
+  "ApplicationLauncherItemProps",
+  "ApplicationLauncherItem",
+  "ApplicationLauncherIconProps",
+  "ApplicationLauncherIcon",
+  "ApplicationLauncherGroup",
+  "ApplicationLauncherContext",
+  "ApplicationLauncherContentProps",
+  "ApplicationLauncherContent",
+  "ApplicationLauncherProps",
+  "ApplicationLauncher",
+];
+
+ruleTester.run("applicationLauncher-deprecated", rule, {
+  valid: [
+    {
+      // No @patternfly/react-core import
+      code: `<ApplicationLauncher />`,
+    },
+    {
+      code: `import { ApplicationLauncher } from '@patternfly/deprecated';`
+    }
+  ],
+  invalid: [
+    {
+      code: `import { ApplicationLauncher } from '@patternfly/react-core'; <ApplicationLauncher />`,
+      output: `import {\n\tApplicationLauncher\n} from '@patternfly/react-core/deprecated'; <ApplicationLauncher />`,
+      errors: [
+        {
+          message: `ApplicationLauncher has been deprecated. Running the fix flag will update your imports to our deprecated package, but we suggest using our new Dropdown or Select implementation.`,
+          type: "ImportDeclaration",
+        },
+      ],
+    },
+    {
+      code: `import { ApplicationLauncher as PFLauncher } from '@patternfly/react-core'; <PFLauncher />`,
+      output: `import {\n\tApplicationLauncher as PFLauncher\n} from '@patternfly/react-core/deprecated'; <PFLauncher />`,
+      errors: [
+        {
+          message: `ApplicationLauncher has been deprecated. Running the fix flag will update your imports to our deprecated package, but we suggest using our new Dropdown or Select implementation.`,
+          type: "ImportDeclaration",
+        },
+      ],
+    },
+    {
+      code: `import { Foo, ${importsToMove.join(', ')}, Bar } from '@patternfly/react-core';`,
+      output: `import {\n\tFoo,\n\tBar\n} from '@patternfly/react-core';\nimport {\n\t${importsToMove.join(',\n\t')}\n} from '@patternfly/react-core/deprecated';`,
+      errors: [
+        {
+          message: `${importsToMove.join(', ').replace(/, (\w+)$/, ', and $1')} have been deprecated. Running the fix flag will update your imports to our deprecated package, but we suggest using our new Dropdown or Select implementation.`,
+          type: "ImportDeclaration",
+        },
+      ],
+    }
+  ],
+});

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -114,7 +114,7 @@ Out:
 
 ### applicationLauncher-deprecate [(8836)](https://github.com/patternfly/patternfly-react/pull/8836)
 
-We've deprecated the `ApplicationLauncher` compoenents. A fix will update code to point to the new deprecated import, but we recommend replacing with `Dropdown` or `Select`
+We've deprecated the `ApplicationLauncher` components. A fix will update code to point to the new deprecated import, but we recommend replacing with `Dropdown` or `Select`
 
 #### Examples
 

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -112,6 +112,24 @@ Out:
 <Alert component="h4" />
 ```
 
+### applicationLauncher-deprecate [(8836)](https://github.com/patternfly/patternfly-react/pull/8836)
+
+We've deprecated the `ApplicationLauncher` compoenents. A fix will update code to point to the new deprecated import, but we recommend replacing with `Dropdown` or `Select`
+
+#### Examples
+
+In:
+
+```jsx
+import { OptionsMenu, OptionsMenuToggle } from '@patternfly/react-core';
+```
+
+Out:
+
+```jsx
+import { OptionsMenu as OptionsMenuDeprecated, OptionsMenuToggle as OptionsMenuToggleDeprecated } from '@patternfly/react-core/deprecated';
+```
+
 ### applicationLauncher-updated-params [(#8756)](https://github.com/patternfly/patternfly-react/pull/8756)
 
 We've updated the `onFavorite` and `onSearch` props for ApplicationLauncher to include the `event` as their first parameter. Handlers may require an update.

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -121,13 +121,13 @@ We've deprecated the `ApplicationLauncher` compoenents. A fix will update code t
 In:
 
 ```jsx
-import { OptionsMenu, OptionsMenuToggle } from '@patternfly/react-core';
+import { ApplicationLauncher } from '@patternfly/react-core';
 ```
 
 Out:
 
 ```jsx
-import { OptionsMenu as OptionsMenuDeprecated, OptionsMenuToggle as OptionsMenuToggleDeprecated } from '@patternfly/react-core/deprecated';
+import { ApplicationLauncher } from '@patternfly/react-core/deprecated';
 ```
 
 ### applicationLauncher-updated-params [(#8756)](https://github.com/patternfly/patternfly-react/pull/8756)


### PR DESCRIPTION
closes #325 

no need to create alias as we aren't offering a replacement applauncher... and it makes things much less likely to cause issues