### PR TITLE
feat: No unused imports rule

### DIFF
--- a/packages/eslint-plugin-pf-codemods/index.js
+++ b/packages/eslint-plugin-pf-codemods/index.js
@@ -33,7 +33,7 @@ const warningRules = [
 const setupRules = [];
 
 // rules that will run after other rules (cleanup imports?)
-const cleanupRules = [];
+const cleanupRules = ["no-unused-imports-v5"];
 
 const createListOfRules = (version, includeBeta = false) => {
   const rules = {};

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/no-unused-imports-v5.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/no-unused-imports-v5.js
@@ -1,0 +1,70 @@
+// Cleanup from other rules
+module.exports = {
+  meta: { fixable: "code" },
+  create: function (context) {
+    const sourceCode = context.getSourceCode();
+
+    const allTokens = [
+      ...new Set(
+        sourceCode.ast.body
+          .filter((node) => node.type !== "ImportDeclaration")
+          .map((node) =>
+            sourceCode
+              .getTokens(node)
+              .filter((token) =>
+                ["JSXIdentifier", "Identifier"].includes(token.type)
+              )
+              .map((token) => token.value)
+          )
+          .flat()
+      ),
+    ];
+
+    return {
+      ImportDeclaration(node) {
+        if (!/@patternfly\/react/.test(node.source.value)) {
+          return;
+        }
+
+        const unusedImports = node.specifiers.filter(
+          (spec) => !allTokens.includes(spec.local.name)
+        );
+
+        if (unusedImports.length === 0) {
+          return;
+        }
+
+        context.report({
+          node,
+          message: `unused PatternFly import${
+            unusedImports.length > 1 ? "s" : ""
+          } ${unusedImports.map((spec) => spec.local.name).join(", ")} from '${
+            node.source.value
+          }'`,
+          fix(fixer) {
+            const getEndRange = (spec) => {
+              const nextComma = sourceCode.getTokenAfter(spec);
+              return nextComma.value === ","
+                ? sourceCode.getTokenAfter(nextComma).range[0]
+                : spec.range[1];
+            };
+
+            const removeWholeImport = () => {
+              const tokenAfter = sourceCode.getTokenAfter(node);
+              return [
+                fixer.remove(node),
+                ...(tokenAfter === ";" ? [fixer.remove(tokenAfter)] : []),
+              ];
+            };
+
+            return unusedImports.length === node.specifiers.length
+              ? removeWholeImport()
+              : unusedImports.map((spec) =>
+                  fixer.removeRange([spec.range[0], getEndRange(spec)])
+                );
+          },
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/no-unused-imports-v5.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/no-unused-imports-v5.js
@@ -43,22 +43,14 @@ module.exports = {
           }'`,
           fix(fixer) {
             const getEndRange = (spec) => {
-              const nextComma = sourceCode.getTokenAfter(spec);
-              return nextComma.value === ","
-                ? sourceCode.getTokenAfter(nextComma).range[0]
+              const tokenAfter = sourceCode.getTokenAfter(spec);
+              return tokenAfter.value === ","
+                ? sourceCode.getTokenAfter(tokenAfter).range[0]
                 : spec.range[1];
             };
 
-            const removeWholeImport = () => {
-              const tokenAfter = sourceCode.getTokenAfter(node);
-              return [
-                fixer.remove(node),
-                ...(tokenAfter === ";" ? [fixer.remove(tokenAfter)] : []),
-              ];
-            };
-
             return unusedImports.length === node.specifiers.length
-              ? removeWholeImport()
+              ? fixer.remove(node)
               : unusedImports.map((spec) =>
                   fixer.removeRange([spec.range[0], getEndRange(spec)])
                 );

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/no-unused-imports-v5.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/no-unused-imports-v5.js
@@ -1,0 +1,48 @@
+const ruleTester = require("../../ruletester");
+const rule = require("../../../lib/rules/v5/no-unused-imports-v5");
+
+ruleTester.run("no-unused-imports-v5", rule, {
+  valid: [
+    {
+      code: `import React from "react";
+      import { Button,  } from "@patternfly/react-core";
+      
+      import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
+      
+      <Button variant="link" icon={<PlusCircleIcon />}>
+        Link
+      </Button>;
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `import React from "react";
+      import { Alert, Button, Title } from "@patternfly/react-core";
+      import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+      import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
+      
+      <Button variant="link" icon={<PlusCircleIcon />}>
+        Link
+      </Button>;`,
+      output: `import React from "react";
+      import { Button,  } from "@patternfly/react-core";
+      
+      import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
+      
+      <Button variant="link" icon={<PlusCircleIcon />}>
+        Link
+      </Button>;`,
+      errors: [
+        {
+          message: `unused PatternFly imports Alert, Title from '@patternfly/react-core'`,
+          type: "ImportDeclaration",
+        },
+        {
+          message: `unused PatternFly import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon'`,
+          type: "ImportDeclaration",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -1407,7 +1407,7 @@ The placement Nav flyouts in the DOM has been changed, if you have Nav elements 
 
 ### no-unused-imports-v5
 
-This rule removes all unused imports from `patternfly/react` packages. It is a special rule which will not run by default. It should be run after all the other rules as a final cleanup using the option `--only no-unused-imports-v5 --fix`.
+This rule, when run with `--fix` option, removes all unused imports from `patternfly/react` packages. It is a cleanup rule which will run after all the rules.
 
 #### Examples
 

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -1437,7 +1437,6 @@ import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-i
 </Button>;
 ```
 
-
 ### notificationBadge-remove-isRead [(#8626)](https://github.com/patternfly/patternfly-react/pull/8626)
 
 We've removed the `isRead` prop from NotificationBadge, use "read" or "unread" on the `variant` prop instead.

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -1405,6 +1405,39 @@ We've update the `aria-label` prop on MenuItemAction, making it required instead
 
 The placement Nav flyouts in the DOM has been changed, if you have Nav elements with flyouts you may need to update some selectors or snapshots in your test suites. This rule will raise a warning, but will not make any changes.
 
+### no-unused-imports-v5
+
+This rule removes all unused imports from `patternfly/react` packages. It is a special rule which will not run by default. It should be run after all the other rules as a final cleanup using the option `--only no-unused-imports-v5 --fix`.
+
+#### Examples
+
+In:
+
+```jsx
+import React from "react";
+import { Alert, Button, Title } from "@patternfly/react-core";
+import CubesIcon from "@patternfly/react-icons/dist/esm/icons/cubes-icon";
+import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
+
+<Button variant="link" icon={<PlusCircleIcon />}>
+  Link
+</Button>;
+```
+
+Out:
+
+```jsx
+import React from "react";
+import { Button,  } from "@patternfly/react-core";
+
+import PlusCircleIcon from "@patternfly/react-icons/dist/esm/icons/plus-circle-icon";
+
+<Button variant="link" icon={<PlusCircleIcon />}>
+  Link
+</Button>;
+```
+
+
 ### notificationBadge-remove-isRead [(#8626)](https://github.com/patternfly/patternfly-react/pull/8626)
 
 We've removed the `isRead` prop from NotificationBadge, use "read" or "unread" on the `variant` prop instead.


### PR DESCRIPTION
Closes #397

Did some refactoring from the v4 rule:
- removing imports does not keep trailing commas, which were causing the file to by syntactically incorrect
- tokens are filtered with `JSXIdentifier` and `Identifier` types, so there are no misleadings, e.g. in this case: `<Title>Button</Title>` if there was an unused `Button` import, it was not removed in the previous version
- errors and fixes are more compact, 1 error and 1 group of fixes per package
- if there are no used imports from the package left, the whole import declaration is removed

The thing I was not been able to repair is to use warnings, instead of errors. There is a clash with the beta rules, which are not updated to use warnings / errors.