### PR TITLE
chore(helpers): renameProps helper refactoring

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/helpers.js
+++ b/packages/eslint-plugin-pf-codemods/lib/helpers.js
@@ -268,6 +268,13 @@ function renamePropsOnNode(context, imports, node, renames) {
         const newPropObject = renamedProps[attribute.name.name];
 
         if (
+          newPropObject.message &&
+          newPropObject.message instanceof Function
+        ) {
+          newPropObject.message = newPropObject.message(node);
+        }
+
+        if (
           newPropObject.newName === undefined ||
           newPropObject.newName === ""
         ) {
@@ -285,9 +292,14 @@ function renamePropsOnNode(context, imports, node, renames) {
             node,
             message:
               newPropObject.message ||
-              `${attribute.name.name} prop for ${node.name.name} has been renamed to ${newPropObject.newName}`,
+              `${attribute.name.name} prop for ${node.name.name} has been ${
+                newPropObject.replace ? "replaced with" : "renamed to"
+              } ${newPropObject.newName}`,
             fix(fixer) {
-              return fixer.replaceText(attribute.name, newPropObject.newName);
+              return fixer.replaceText(
+                newPropObject.replace ? attribute : attribute.name,
+                newPropObject.newName
+              );
             },
           });
         }

--- a/packages/eslint-plugin-pf-codemods/lib/helpers.js
+++ b/packages/eslint-plugin-pf-codemods/lib/helpers.js
@@ -255,7 +255,7 @@ function createAliasImportSpecifiers(specifiers, aliasSuffix) {
   });
 }
 
-function renameProps0(context, imports, node, renames) {
+function renamePropsOnNode(context, imports, node, renames) {
   const componentName = imports.find((imp) => imp.local.name === node.name.name)
     ?.imported.name;
 
@@ -263,10 +263,7 @@ function renameProps0(context, imports, node, renames) {
     const renamedProps = renames[componentName];
 
     node.attributes
-      .filter(
-        (attribute) =>
-          attribute.name && renamedProps.hasOwnProperty(attribute.name.name)
-      )
+      .filter((attribute) => renamedProps.hasOwnProperty(attribute.name.name))
       .forEach((attribute) => {
         const newPropObject = renamedProps[attribute.name.name];
 
@@ -318,7 +315,7 @@ function renameProps(renames, packageName = "@patternfly/react-core") {
 
     return {
       JSXOpeningElement(node) {
-        renameProps0(context, imports, node, renames);
+        renamePropsOnNode(context, imports, node, renames);
       },
     };
   };
@@ -708,7 +705,7 @@ module.exports = {
   moveSpecifiers,
   pfPackageMatches,
   renameProp,
-  renameProps0,
+  renamePropsOnNode,
   renameProps,
   renameComponents,
   splitImportSpecifiers,

--- a/packages/eslint-plugin-pf-codemods/lib/helpers.js
+++ b/packages/eslint-plugin-pf-codemods/lib/helpers.js
@@ -23,9 +23,10 @@ function moveSpecifiers(
       const toParts = toPackage.split("/");
       //expecting @patternfly/{package}/dist/esm/components/{Component}/index.js
       //needing toPath to look like fromPath with the designator before /components
-      const fromParts = importSpecifiersToMove[0].parent.source.value.split("/");
+      const fromParts =
+        importSpecifiersToMove[0].parent.source.value.split("/");
       if (toParts[0] === "@patternfly" && toParts.length === 3) {
-        fromParts.splice(4, 0, toParts[2])
+        fromParts.splice(4, 0, toParts[2]);
         modifiedToPackage = fromParts.join("/");
       }
     }
@@ -42,7 +43,8 @@ function moveSpecifiers(
     const src = context.getSourceCode();
     const existingToPackageImportDeclaration = src.ast.body.find(
       (node) =>
-        node.type === "ImportDeclaration" && [modifiedToPackage, toPackage].includes(node.source.value)
+        node.type === "ImportDeclaration" &&
+        [modifiedToPackage, toPackage].includes(node.source.value)
     );
     const existingToPackageSpecifiers =
       existingToPackageImportDeclaration?.specifiers?.map((specifier) =>
@@ -54,7 +56,10 @@ function moveSpecifiers(
         const [newToPackageSpecifiers, fromPackageSpecifiers] =
           splitImportSpecifiers(node, importNames);
 
-        if (!newToPackageSpecifiers.length || !pfPackageMatches(fromPackage, node.source.value))
+        if (
+          !newToPackageSpecifiers.length ||
+          !pfPackageMatches(fromPackage, node.source.value)
+        )
           return {};
 
         const newAliasToPackageSpecifiers = createAliasImportSpecifiers(
@@ -193,13 +198,16 @@ function moveSpecifiers(
 
 function pfPackageMatches(packageName, nodeSrc) {
   const parts = packageName.split("/");
-  const regex = new RegExp('^' +
-    parts[0] + '\/' + parts[1] +
-    '(\/dist\/(esm|js))?' +
-    (parts[2] ? ('\/' + parts[2]) : '') +
-    '(\/(components|helpers)\/.*)?$'
+  const regex = new RegExp(
+    "^" +
+      parts[0] +
+      "/" +
+      parts[1] +
+      "(/dist/(esm|js))?" +
+      (parts[2] ? "/" + parts[2] : "") +
+      "(/(components|helpers)/.*)?$"
   );
-  return regex.test(nodeSrc)
+  return regex.test(nodeSrc);
 }
 
 /**
@@ -214,10 +222,10 @@ function getPackageImports(context, packageName, importNames = []) {
     .getSourceCode()
     .ast.body.filter((node) => node.type === "ImportDeclaration")
     .filter((node) => {
-      if(packageName.startsWith("@patternfly")) {
+      if (packageName.startsWith("@patternfly")) {
         return pfPackageMatches(packageName, node.source.value);
       }
-      return node.source.value === packageName
+      return node.source.value === packageName;
     })
     .map((node) => node.specifiers)
     .reduce((acc, val) => acc.concat(val), []);
@@ -267,12 +275,11 @@ function renamePropsOnNode(context, imports, node, renames) {
       .forEach((attribute) => {
         const newPropObject = renamedProps[attribute.name.name];
 
-        if (
-          newPropObject.message &&
-          newPropObject.message instanceof Function
-        ) {
-          newPropObject.message = newPropObject.message(node);
-        }
+        const message = newPropObject.message
+          ? newPropObject.message instanceof Function
+            ? newPropObject.message(node)
+            : newPropObject.message
+          : undefined;
 
         if (
           newPropObject.newName === undefined ||
@@ -281,7 +288,7 @@ function renamePropsOnNode(context, imports, node, renames) {
           context.report({
             node,
             message:
-              newPropObject.message ||
+              message ||
               `${attribute.name.name} prop for ${node.name.name} has been removed`,
             fix(fixer) {
               return fixer.replaceText(attribute, "");
@@ -291,7 +298,7 @@ function renamePropsOnNode(context, imports, node, renames) {
           context.report({
             node,
             message:
-              newPropObject.message ||
+              message ||
               `${attribute.name.name} prop for ${node.name.name} has been ${
                 newPropObject.replace ? "replaced with" : "renamed to"
               } ${newPropObject.newName}`,
@@ -614,10 +621,10 @@ function addCallbackParam(componentsArray, propMap) {
                     message: `The "${attribute.name.name}" prop for ${node.name.name} has been updated so that the "${newParam}" parameter is the first parameter. "${attribute.name.name}" handlers may require an update.`,
                     fix(fixer) {
                       const fixes = [];
-                      
+
                       const createParamAdditionFix = (params) => {
                         const firstParam = params[0];
-                        
+
                         const replacementParams = `${newParam}, ${context
                           .getSourceCode()
                           .getText(firstParam)}`;

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v4/accordion-remove-noBoxShadow.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v4/accordion-remove-noBoxShadow.js
@@ -1,11 +1,15 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/4022
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'Accordion',
-    {'noBoxShadow': ''},
-    node =>  `noBoxShadow prop has been removed for ${node.name.name}. If a shadow is needed, the accordion can be placed in a card, or a shadow can be applied either using CSS or a box-shadow utility class`
-  ),
+  meta: { fixable: "code" },
+  create: renameProps({
+    Accordion: {
+      noBoxShadow: {
+        newName: "",
+        message: (node) =>
+          `noBoxShadow prop has been removed for ${node.name.name}. If a shadow is needed, the accordion can be placed in a card, or a shadow can be applied either using CSS or a box-shadow utility class`,
+      },
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v4/application-launcher-rename-dropdownItems.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v4/application-launcher-rename-dropdownItems.js
@@ -1,11 +1,13 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/3929
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'ApplicationLauncher',
-    {'dropdownItems': 'items'},
-    node => `dropdownItems prop has been removed for ${node.name.name}. Use items instead`
-  )
+  meta: { fixable: "code" },
+  create: renameProps({
+    ApplicationLauncher: {
+      dropdownItems: {
+        newName: "items",
+      },
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v4/chart-remove-allowZoom.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v4/chart-remove-allowZoom.js
@@ -1,38 +1,65 @@
-const { renameProps0, getPackageImports, ensureImports } = require('../../helpers');
+const { getPackageImports } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/4278
-const renames = {
-  'Chart': {
-    allowZoom: 'containerComponent={<VictoryZoomContainer />}'
-  },
-  'ChartGroup': {
-    allowZoom: ''
-  }
-};
-
 module.exports = {
-  meta: { fixable: 'code' },
-  create: function(context) {
-    const imports = getPackageImports(context, '@patternfly/react-charts');
-    const victoryCoreImports = getPackageImports(context, 'victory-zoom-container');
+  meta: { fixable: "code" },
+  create: function (context) {
+    const imports = getPackageImports(context, "@patternfly/react-charts");
+    const victoryCoreImports = getPackageImports(
+      context,
+      "victory-zoom-container"
+    );
     if (victoryCoreImports.length === 0) {
-      const lastImportNode = context.getSourceCode().ast.body
-        .filter(node => node.type === 'ImportDeclaration')
+      const lastImportNode = context
+        .getSourceCode()
+        .ast.body.filter((node) => node.type === "ImportDeclaration")
         .pop();
-      const importStatement = `import { VictoryZoomContainer } from 'victory-zoom-container';`
+      const importStatement = `import { VictoryZoomContainer } from 'victory-zoom-container';`;
       context.report({
         node: lastImportNode,
         message: `add missing ${importStatement}`,
         fix(fixer) {
-          return fixer.insertTextAfter(lastImportNode, '\n' + importStatement)
-        }
+          return fixer.insertTextAfter(lastImportNode, "\n" + importStatement);
+        },
       });
     }
 
-    return imports.length === 0 ? {} : {
-      JSXOpeningElement(node) {
-        renameProps0(context, imports, node, renames);
-      },
-    };
-  }
+    return imports.length === 0
+      ? {}
+      : {
+          JSXOpeningElement(node) {
+            const componentName = imports.find(
+              (imp) => imp.local.name === node.name.name
+            )?.imported.name;
+
+            if (["Chart", "ChartGroup"].includes(componentName)) {
+              const allowZoomAttr = node.attributes.find(
+                (attribute) => attribute.name.name === "allowZoom"
+              );
+              if (allowZoomAttr) {
+                if (componentName === "Chart") {
+                  context.report({
+                    node,
+                    message: `allowZoom prop for Chart has been replaced with containerComponent={<VictoryZoomContainer />}`,
+                    fix(fixer) {
+                      return fixer.replaceText(
+                        allowZoomAttr,
+                        "containerComponent={<VictoryZoomContainer />}"
+                      );
+                    },
+                  });
+                } else {
+                  context.report({
+                    node,
+                    message: `allowZoom prop for ChartGroup has been removed`,
+                    fix(fixer) {
+                      return fixer.replaceText(allowZoomAttr, "");
+                    },
+                  });
+                }
+              }
+            }
+          },
+        };
+  },
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v4/chipgroup-remove-props.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v4/chipgroup-remove-props.js
@@ -1,20 +1,20 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/4246
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    ['ChipGroup'],
-    { withToolbar: 'categoryName="pf-codemod-category"', headingLevel: '' },
-    (node, attribute) => {
-      if (attribute.name.name === 'withToolbar') {
-        return `withToolbar has been removed from ${node.name.name}. Add the categoryName prop instead for a category.`
-      }
-      else {
-        return `headingLevel has been removed from ${node.name.name} since the category name is now a <span>`
-      }
+  meta: { fixable: "code" },
+  create: renameProps({
+    ChipGroup: {
+      withToolbar: {
+        newName: 'categoryName="pf-codemod-category"',
+        message: (node) =>
+          `withToolbar has been removed from ${node.name.name}. Add the categoryName prop instead for a category.`,
+        replace: true,
+      },
+      headingLevel: {
+        newName: "",
+        message: node => `headingLevel has been removed from ${node.name.name} since the category name is now a <span>`,
+      },
     },
-    false,
-    false
-  )
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v4/dropdown-toggle-rename-iconComponent.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v4/dropdown-toggle-rename-iconComponent.js
@@ -1,11 +1,13 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/4038
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'DropdownToggle',
-    { iconComponent: 'toggleIndicator' },
-    node =>  `iconComponent prop has been removed for ${node.name.name} in favor of toggleIndicator.`
-  )
+  meta: { fixable: "code" },
+  create: renameProps({
+    DropdownToggle: {
+      iconComponent: {
+        newName: "toggleIndicator",
+      },
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v4/empty-state-icon-removed-props.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v4/empty-state-icon-removed-props.js
@@ -1,11 +1,20 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/4065
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'EmptyStateIcon',
-    { size: '', title: '' },
-    (node, attribute) => `Removed prop ${attribute.name.name} from ${node.name.name}. Use the icon prop instead.`
-  )
+  meta: { fixable: "code" },
+  create: renameProps({
+    EmptyStateIcon: {
+      size: {
+        newName: "",
+        message: (node) =>
+          `Removed prop size from ${node.name.name}. Use the icon prop instead.`,
+      },
+      title: {
+        newName: "",
+        message: (node) =>
+          `Removed prop title from ${node.name.name}. Use the icon prop instead.`,
+      },
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v4/label-remove-isCompact.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v4/label-remove-isCompact.js
@@ -1,11 +1,13 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/4116
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'Label',
-    { isCompact: '' },
-    (node, attribute) => `${attribute.name.name} prop for ${node.name.name} has been removed`
-  )
+  meta: { fixable: "code" },
+  create: renameProps({
+    Label: {
+      isCompact: {
+        newName: "",
+      },
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v4/modal-variant.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v4/modal-variant.js
@@ -1,11 +1,18 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/3920
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'Modal',
-    {'isSmall': 'variant="small"', 'isLarge': 'variant="large"'},
-    (node, attribute, replacement) => `${node.name.name} has replaced ${attribute.name.name} prop with ${replacement}`
-  )
+  meta: { fixable: "code" },
+  create: renameProps({
+    Modal: {
+      isSmall: {
+        newName: 'variant="small"',
+        replace: true,
+      },
+      isLarge: {
+        newName: 'variant="large"',
+        replace: true,
+      },
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v4/page-header-prop-rename.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v4/page-header-prop-rename.js
@@ -1,13 +1,11 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/4246
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'PageHeader',
-    {
-      'toolbar': 'headerTools'
+  meta: { fixable: "code" },
+  create: renameProps({
+    PageHeader: {
+      toolbar: { newName: "headerTools" },
     },
-    node => `toolbar prop has been removed from ${node.name.name}. Use headerTools instead`
-  ),
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v4/remove-gutter-size.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v4/remove-gutter-size.js
@@ -1,12 +1,17 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
+
+let renames = {};
+["Gallery", "Grid", "Level", "Split", "Stack"].forEach((component) => {
+  renames[component] = {
+    gutter: {
+      newName: "hasGutter",
+      replace: true,
+    },
+  };
+});
 
 // https://github.com/patternfly/patternfly-react/pull/4014
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    ['Gallery', 'Grid', 'Level', 'Split', 'Stack'],
-    { 'gutter': 'hasGutter' },
-    node => `gutter prop has been removed for ${node.name.name}. Use hasGutter instead`,
-    true
-  )
+  meta: { fixable: "code" },
+  create: renameProps(renames),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v4/select-rename-isExpanded.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v4/select-rename-isExpanded.js
@@ -1,11 +1,11 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/3945
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'Select',
-    { 'isExpanded': 'isOpen' },
-    node => `isExpanded has been renamed to isOpen for ${node.name.name}`
-  )
+  meta: { fixable: "code" },
+  create: renameProps({
+    Select: {
+      isExpanded: "isOpen",
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v4/skip-to-content-remove-component.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v4/skip-to-content-remove-component.js
@@ -1,11 +1,15 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/4116
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    ['SkipToContent'],
-    { 'component': '' },
-    node => `Component prop was removed from ${node.name.name} in favor of always using an anchor tag`
-  )
+  meta: { fixable: "code" },
+  create: renameProps({
+    SkipToContent: {
+      component: {
+        newName: "",
+        message: (node) =>
+          `component prop was removed from ${node.name.name} in favor of always using an anchor tag`,
+      },
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v4/tab-rename-variant.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v4/tab-rename-variant.js
@@ -1,4 +1,4 @@
-const { getPackageImports, renameProps0 } = require('../../helpers');
+const { getPackageImports, renamePropsOnNode } = require('../../helpers');
 
 // https://github.com/patternfly/patternfly-react/pull/4146
 module.exports = {
@@ -35,9 +35,9 @@ module.exports = {
         }
       },
       JSXOpeningElement(node) {
-        renameProps0(context, tabImports, node, {
+        renamePropsOnNode(context, tabImports, node, {
           'Tabs' : {
-            'variant': 'component'
+            'variant': { newName: 'component' }
           }
         });
       }

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v4/wizard-rename-text.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v4/wizard-rename-text.js
@@ -1,11 +1,11 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/4014
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'WizardNavItem',
-    {'text': 'content'},
-    node => `text prop has been removed for ${node.name.name}. Use content instead`
-  )
+  meta: { fixable: "code" },
+  create: renameProps({
+    WizardNavItem: {
+      text: "content",
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/alert-remove-ariaLabel.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/alert-remove-ariaLabel.js
@@ -1,12 +1,15 @@
-const { renameProp } = require("../../helpers");
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/8649
 module.exports = {
   meta: { fixable: "code" },
-  create: renameProp(
-    "Alert",
-    { "aria-label": "" },
-    (node, attribute) =>
-      `${attribute.name.name} prop for ${node.name.name} has been removed and should not be used as it is not well supported on div elements without a role.`
-  ),
+  create: renameProps({
+    Alert: {
+      "aria-label": {
+        newName: "",
+        message: (node) =>
+          `aria-label prop for ${node.name.name} has been removed and should not be used as it is not well supported on div elements without a role.`,
+      },
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/alert-remove-titleHeadingLevel.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/alert-remove-titleHeadingLevel.js
@@ -1,11 +1,11 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
-  // https://github.com/patternfly/patternfly-react/pull/8518
-  module.exports = {
-    meta: { fixable: 'code' },
-    create: renameProp(
-      'Alert',
-      {'titleHeadingLevel': 'component'},
-      node =>  `titleHeadingLevel prop has been removed for ${node.name.name} and replaced with the component prop.`
-    ),
-  };
+// https://github.com/patternfly/patternfly-react/pull/8518
+module.exports = {
+  meta: { fixable: "code" },
+  create: renameProps({
+    Alert: {
+      titleHeadingLevel: "component",
+    },
+  }),
+};

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/backgroundImage-update-props.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/backgroundImage-update-props.js
@@ -1,4 +1,4 @@
-const { getPackageImports, renameProps0 } = require("../../helpers");
+const { getPackageImports, renamePropsOnNode } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/8931
 module.exports = {
@@ -21,7 +21,7 @@ module.exports = {
               return;
             }
 
-            renameProps0(context, backgroundImageImports, node, {
+            renamePropsOnNode(context, backgroundImageImports, node, {
               BackgroundImage: {
                 filter: "",
               },

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/button-remove-isSmallisLarge.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/button-remove-isSmallisLarge.js
@@ -1,12 +1,42 @@
-const { renameProps } = require('../../helpers');
+const { getPackageImports } = require("../../helpers");
 
-  // https://github.com/patternfly/patternfly-react/pull/8144
-  module.exports = {
-    meta: { fixable: 'code' },
-    create: renameProps({
-      'Button': {
-        'isSmall': 'size="sm"',
-        'isLarge': 'size="lg"'
-      }
-    }),
-  };
+// https://github.com/patternfly/patternfly-react/pull/8144
+module.exports = {
+  meta: { fixable: "code" },
+  create: function (context) {
+    const buttonImport = getPackageImports(
+      context,
+      "@patternfly/react-core"
+    ).find((specifier) => specifier.imported.name === "Button");
+
+    if (!buttonImport) {
+      return {};
+    }
+
+    const propMap = {
+      isSmall: 'size="sm"',
+      isLarge: 'size="lg"',
+    };
+
+    return {
+      JSXOpeningElement(node) {
+        if (node.name.name !== buttonImport.local.name) {
+          return;
+        }
+
+        node.attributes
+          .filter((attribute) => propMap.hasOwnProperty(attribute.name.name))
+          .forEach((attribute) => {
+            const newProp = propMap[attribute.name.name];
+            context.report({
+              node,
+              message: `use ${newProp} instead of ${attribute.name.name} prop for ${node.name.name}`,
+              fix(fixer) {
+                return fixer.replaceText(attribute, newProp);
+              },
+            });
+          });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/card-remove-isHoverable.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/card-remove-isHoverable.js
@@ -1,12 +1,15 @@
-const {renameProp} = require("../../helpers");
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/8196
 module.exports = {
-  meta: {fixable: "code"},
-  create: renameProp(
-    "Card",
-    {isHoverable: ""},
-    (node, attribute) =>
-      `${attribute.name.name} prop for ${node.name.name} has been removed and should be replaced with isSelectable or isSelectableRaised as needed.`
-  ),
+  meta: { fixable: "code" },
+  create: renameProps({
+    Card: {
+      isHoverable: {
+        newName: "",
+        message: (node) =>
+          `isHoverable prop for ${node.name.name} has been removed and should be replaced with isSelectable or isSelectableRaised as needed.`,
+      },
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/clipboardCopy-remove-switchDelay.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/clipboardCopy-remove-switchDelay.js
@@ -1,11 +1,11 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
-  // https://github.com/patternfly/patternfly-react/pull/8619
-  module.exports = {
-    meta: { fixable: 'code' },
-    create: renameProp(
-      'ClipboardCopy',
-      {'switchDelay': ''},
-      node =>  `switchDelay prop has been removed for ${node.name.name}`
-    ),
-  };
+// https://github.com/patternfly/patternfly-react/pull/8619
+module.exports = {
+  meta: { fixable: "code" },
+  create: renameProps({
+    ClipboardCopy: {
+      switchDelay: "",
+    },
+  }),
+};

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/codeEditor-remove-props.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/codeEditor-remove-props.js
@@ -1,18 +1,21 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
-  // https://github.com/patternfly/patternfly-react/pull/8624
-  module.exports = {
-    meta: { fixable: 'code' },
-    create: renameProp(
-      'CodeEditor',
-      {
-        entryDelay: '',
-        exitDelay: '',
-        maxWidth: '',
-        position: '',
-        toolTipText: ''
-      },
-      (node, attribute) => 
-        `${attribute.name.name} has been removed for ${node.name.name}. This can instead be passed via the tooltipProps prop`
-    ),
-  };
+let propRenames = {};
+
+["entryDelay", "exitDelay", "maxWidth", "position", "toolTipText"].forEach(
+  (prop) => {
+    propRenames[prop] = {
+      newName: "",
+      message: (node) =>
+        `${prop} has been removed for ${node.name.name}. This can instead be passed via the tooltipProps prop`,
+    };
+  }
+);
+
+// https://github.com/patternfly/patternfly-react/pull/8624
+module.exports = {
+  meta: { fixable: "code" },
+  create: renameProps({
+    CodeEditor: propRenames,
+  }),
+};

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/datalist-remove-props.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/datalist-remove-props.js
@@ -1,19 +1,25 @@
-const {renameProp} = require("../../helpers");
+const { renameProps } = require("../../helpers");
+
+const propRemovals = {
+  itemOrder: {
+    newName: "",
+  },
+};
+
+["onDragFinish", "onDragStart", "onDragMove", "onDragCancel"].forEach(
+  (prop) => {
+    propRemovals[prop] = {
+      newName: "",
+      message: (node) =>
+        `${prop} prop for ${node.name.name} has been removed. Implement drag and drop using the DragDrop component instead.`,
+    };
+  }
+);
 
 // https://github.com/patternfly/patternfly-react/pull/8388
-
 module.exports = {
-  meta: {fixable: "code"},
-  create: renameProp(
-    "DataList",
-    {
-      onDragFinish: "",
-      onDragStart: "",
-      onDragMove: "",
-      onDragCancel: "",
-      itemOrder: "",
-    },
-    (node, attribute) =>
-    attribute.name?.name.includes("onDrag") ? `${attribute.name.name} prop for ${node.name.name} has been removed. Implement drag and drop using the DragDrop component instead.` :  `${attribute.name.name} prop for ${node.name.name} has been removed.`
-  ),
+  meta: { fixable: "code" },
+  create: renameProps({
+    DataList: propRemovals,
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/datalist-remove-selectableRow.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/datalist-remove-selectableRow.js
@@ -1,4 +1,4 @@
-const { renameProp, getPackageImports} = require('../../helpers');
+const { getPackageImports} = require('../../helpers');
 
 //https://github.com/patternfly/patternfly-react/pull/8827
 module.exports = {

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/divider-remove-isVertical.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/divider-remove-isVertical.js
@@ -1,11 +1,16 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/8199
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'Divider',
-    {'isVertical': `orientation={{ default: 'vertical' }}`},
-    node =>  `isVertical prop has been removed for ${node.name.name} and replaced with the orientation prop, which can specify verticality at various breakpoints.`
-  ),
+  meta: { fixable: "code" },
+  create: renameProps({
+    Divider: {
+      isVertical: {
+        newName: `orientation={{ default: 'vertical' }}`,
+        replace: true,
+        message: (node) =>
+          `isVertical prop has been removed for ${node.name.name} and replaced with the orientation prop, which can specify verticality at various breakpoints.`,
+      },
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/dropdownItem-remove-isHovered.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/dropdownItem-remove-isHovered.js
@@ -1,11 +1,9 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
-  // https://github.com/patternfly/patternfly-react/pull/8179
-  module.exports = {
-    meta: { fixable: 'code' },
-    create: renameProp(
-      'DropdownItem',
-      {'isHovered': ''},
-      node =>  `isHovered prop has been removed for ${node.name.name}.`
-    ),
-  };
+// https://github.com/patternfly/patternfly-react/pull/8179
+module.exports = {
+  meta: { fixable: "code" },
+  create: renameProps({
+    DropdownItem: { isHovered: "" },
+  }),
+};

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/dropdownMenu-remove-openedOnEnter.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/dropdownMenu-remove-openedOnEnter.js
@@ -1,12 +1,11 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/8179
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'DropdownMenu',
-    { openedOnEnter: '' },
-    (node, attribute) =>
-      `${attribute.name.name} prop for ${node.name.name} has been removed.`
-  ),
+  meta: { fixable: "code" },
+  create: renameProps({
+    DropdownMenu: {
+      openedOnEnter: "",
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/fileUpload-remove-onChange.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/fileUpload-remove-onChange.js
@@ -1,12 +1,15 @@
-const { renameProp } = require("../../helpers");
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/8155
 module.exports = {
   meta: { fixable: "code" },
-  create: renameProp(
-    "FileUpload",
-    { onChange: "" },
-    (node, attribute) =>
-      `${attribute.name.name} prop for ${node.name.name} has been removed and should be replaced with onFileInputChange, onTextChange, onDataChange, and onClearClick as needed.`
-  ),
+  create: renameProps({
+    FileUpload: {
+      onChange: {
+        newName: "",
+        message: (node) =>
+          `onChange prop for ${node.name.name} has been removed and should be replaced with onFileInputChange, onTextChange, onDataChange, and onClearClick as needed.`,
+      },
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/formhelpertext-remove-props.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/formhelpertext-remove-props.js
@@ -1,17 +1,19 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
+
+const propRemovals = {};
+
+["isError", "isHidden", "icon", "component"].forEach((prop) => {
+  propRemovals[prop] = {
+    newName: "",
+    message: (node) =>
+      `${prop} prop for ${node.name.name} has been removed. Use HelperText and HelperTextItem directly in children.`,
+  };
+});
 
 // https://github.com/patternfly/patternfly-react/pull/8810
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'FormHelperText',
-    { 
-      isError: '',
-      isHidden: '',
-      icon: '',
-      component: ''
-    },
-    (node, attribute) =>
-      `${attribute.name.name} prop for ${node.name.name} has been removed. Use HelperText and HelperTextItem directly in children.`
-  ),
+  meta: { fixable: "code" },
+  create: renameProps({
+    FormHelperText: propRemovals,
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/label-remove-isTruncated.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/label-remove-isTruncated.js
@@ -1,11 +1,15 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/8771
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'Label',
-    {'isTruncated': ''},
-    node =>  `isTruncated prop has been removed for ${node.name.name}. This is now the default behavior. Note that there is also a new property (maxTextWidth) to customize when truncation will occur.`
-  ),
+  meta: { fixable: "code" },
+  create: renameProps({
+    Label: {
+      isTruncated: {
+        newName: "",
+        message: (node) =>
+          `isTruncated prop has been removed for ${node.name.name}. This is now the default behavior. Note that there is also a new property (maxTextWidth) to customize when truncation will occur.`,
+      },
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/loginPage-update-props.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/loginPage-update-props.js
@@ -1,4 +1,4 @@
-const { getPackageImports, renameProps0 } = require("../../helpers");
+const { getPackageImports, renamePropsOnNode } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/8931
 module.exports = {
@@ -21,7 +21,7 @@ module.exports = {
               return;
             }
 
-            renameProps0(context, loginPageImports, node, {
+            renamePropsOnNode(context, loginPageImports, node, {
               LoginPage: {
                 backgroundImgAlt: "",
               },

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/numberInput-remove-allowEmptyInput.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/numberInput-remove-allowEmptyInput.js
@@ -1,11 +1,15 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
-  // https://github.com/patternfly/patternfly-react/pull/8715
-  module.exports = {
-    meta: { fixable: 'code' },
-    create: renameProp(
-      'NumberInput',
-      {'allowEmptyInput': ''},
-      node =>  `allowEmptyInput prop has been removed for ${node.name.name}, allowing empty input is now the default behavior.`
-    ),
-  };
+// https://github.com/patternfly/patternfly-react/pull/8715
+module.exports = {
+  meta: { fixable: "code" },
+  create: renameProps({
+    NumberInput: {
+      allowEmptyInput: {
+        newName: "",
+        message: (node) =>
+          `allowEmptyInput prop has been removed for ${node.name.name}, allowing empty input is now the default behavior.`,
+      },
+    },
+  }),
+};

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/overflowMenuDropdownItem-renamed-prop.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/overflowMenuDropdownItem-renamed-prop.js
@@ -1,12 +1,15 @@
-const { renameProp } = require("../../helpers");
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/8359
 module.exports = {
   meta: { fixable: "code" },
-  create: renameProp(
-    "OverflowMenuDropdownItem",
-    { index: "itemId" },
-    (node) =>
-      `The "index" prop for ${node.name.name} has been renamed to "itemId", and its type has been updated to either a number or string.`
-  ),
+  create: renameProps({
+    OverflowMenuDropdownItem: {
+      index: {
+        newName: "itemId",
+        message: (node) =>
+          `the "index" prop for ${node.name.name} has been renamed to "itemId", and its type has been updated to either a number or string.`,
+      },
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/popper-remove-popperMatchesTriggerWidth.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/popper-remove-popperMatchesTriggerWidth.js
@@ -1,12 +1,15 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
-  // https://github.com/patternfly/patternfly-react/pull/8724
-  module.exports = {
-    meta: { fixable: 'code' },
-    create: 
-    renameProp(
-      'Popper',
-      {'popperMatchesTriggerWidth': ''},
-      node =>  `popperMatchesTriggerWidth prop has been removed for ${node.name.name}.  The width can instead be modified via the new minWidth, maxWidth, and width properties`
-    ),
-  };
+// https://github.com/patternfly/patternfly-react/pull/8724
+module.exports = {
+  meta: { fixable: "code" },
+  create: renameProps({
+    Popper: {
+      popperMatchesTriggerWidth: {
+        newName: "",
+        message: (node) =>
+          `popperMatchesTriggerWidth prop has been removed for ${node.name.name}. The width can instead be modified via the new minWidth, maxWidth, and width properties`,
+      },
+    },
+  }),
+};

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/simpleList-remove-isCurrent.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/simpleList-remove-isCurrent.js
@@ -1,11 +1,9 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/8132
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'SimpleList',
-    {'isCurrent': 'isActive'},
-    node =>  `isCurrent prop has been removed for ${node.name.name} and replaced with the isActive prop.`
-  ),
+  meta: { fixable: "code" },
+  create: renameProps({
+    SimpleList: { isCurrent: "isActive" },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/spinner-remove-isSvg.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/spinner-remove-isSvg.js
@@ -1,11 +1,14 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/8616
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'Spinner',
-    {'isSVG': ``},
-    node =>  `Spinner's isSVG prop has been removed because Spinner now exclusively uses an SVG.`
-  ),
+  meta: { fixable: "code" },
+  create: renameProps({
+    Spinner: {
+      isSVG: {
+        newName: "",
+        message: `Spinner's isSVG prop has been removed because Spinner now exclusively uses an SVG.`,
+      },
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/tabs-remove-hasSecondaryBorderBottom.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/tabs-remove-hasSecondaryBorderBottom.js
@@ -1,11 +1,11 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/8517
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'Tabs',
-    {'hasSecondaryBorderBottom': ''},
-    node =>  `hasSecondaryBorderBottom prop has been removed for ${node.name.name}.`
-  ),
+  meta: { fixable: "code" },
+  create: renameProps({
+    Tabs: {
+      hasSecondaryBorderBottom: "",
+    },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/toolbar-remove-visiblity.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/toolbar-remove-visiblity.js
@@ -1,11 +1,9 @@
-const { renameProp } = require('../../helpers');
+const { renameProps } = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/8212
 module.exports = {
-  meta: { fixable: 'code' },
-  create: renameProp(
-    'ToolbarContent',
-    { visiblity: 'visibility' },
-    (node, attribute) => `${attribute.name.name} prop for ${node.name.name} has been removed and replaced with the visibility prop.`
-  )
+  meta: { fixable: "code" },
+  create: renameProps({
+    ToolbarContent: { visiblity: "visibility" },
+  }),
 };

--- a/packages/eslint-plugin-pf-codemods/test/rules/v4/application-launcher-rename-dropdownItems.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v4/application-launcher-rename-dropdownItems.js
@@ -16,7 +16,7 @@ ruleTester.run("application-launcher-rename-dropdownItems", rule, {
       code:   `import { ApplicationLauncher } from '@patternfly/react-core'; <ApplicationLauncher dropdownItems={[1,2,3]} />`,
       output: `import { ApplicationLauncher } from '@patternfly/react-core'; <ApplicationLauncher items={[1,2,3]} />`,
       errors: [{
-        message: `dropdownItems prop has been removed for ApplicationLauncher. Use items instead`,
+        message: `dropdownItems prop for ApplicationLauncher has been renamed to items`,
         type: "JSXOpeningElement",
       }]
     },

--- a/packages/eslint-plugin-pf-codemods/test/rules/v4/chart-remove-allowZoom.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v4/chart-remove-allowZoom.js
@@ -41,7 +41,7 @@ import { VictoryZoomContainer } from 'victory-zoom-container';
           type: "ImportDeclaration",
         },
         {
-          message: `allowZoom prop for Chart has been renamed to containerComponent={<VictoryZoomContainer />}`,
+          message: `allowZoom prop for Chart has been replaced with containerComponent={<VictoryZoomContainer />}`,
           type: "JSXOpeningElement",
         },
         {

--- a/packages/eslint-plugin-pf-codemods/test/rules/v4/chart-remove-allowZoom.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v4/chart-remove-allowZoom.js
@@ -73,7 +73,7 @@ import { VictoryZoomContainer } from 'victory-zoom-container';
           type: "ImportDeclaration",
         },
         {
-          message: `allowZoom prop for Chart has been renamed to containerComponent={<VictoryZoomContainer />}`,
+          message: `allowZoom prop for Chart has been replaced with containerComponent={<VictoryZoomContainer />}`,
           type: "JSXOpeningElement",
         },
         {

--- a/packages/eslint-plugin-pf-codemods/test/rules/v4/chipgroup-remove-props.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v4/chipgroup-remove-props.js
@@ -19,16 +19,6 @@ ruleTester.run("chipgroup-remove-props", rule, {
       ]
     },
     {
-      code:   `import { ChipGroup } from '@patternfly/react-core'; <ChipGroup categoryName="I already have a categoryName" withToolbar>button</ChipGroup>`,
-      output: `import { ChipGroup } from '@patternfly/react-core'; <ChipGroup categoryName="I already have a categoryName" >button</ChipGroup>`,
-      errors: [
-        {
-          message: `withToolbar has been removed from ChipGroup. Add the categoryName prop instead for a category.`,
-          type: "JSXOpeningElement",
-        },
-      ]
-    },
-    {
       code:   `import { ChipGroup } from '@patternfly/react-core'; <ChipGroup headingLevel="123">button</ChipGroup>`,
       output: `import { ChipGroup } from '@patternfly/react-core'; <ChipGroup >button</ChipGroup>`,
       errors: [

--- a/packages/eslint-plugin-pf-codemods/test/rules/v4/dropdown-toggle-rename-iconComponent.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v4/dropdown-toggle-rename-iconComponent.js
@@ -12,7 +12,7 @@ ruleTester.run("dropdown-toggle-rename-iconComponent", rule, {
       code:   `import { DropdownToggle } from '@patternfly/react-core'; <DropdownToggle iconComponent={CaretDownIcon} />`,
       output: `import { DropdownToggle } from '@patternfly/react-core'; <DropdownToggle toggleIndicator={CaretDownIcon} />`,
       errors: [{
-        message: `iconComponent prop has been removed for DropdownToggle in favor of toggleIndicator.`,
+        message: `iconComponent prop for DropdownToggle has been renamed to toggleIndicator`,
         type: "JSXOpeningElement",
       }]
     },

--- a/packages/eslint-plugin-pf-codemods/test/rules/v4/modal-variant.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v4/modal-variant.js
@@ -16,7 +16,7 @@ ruleTester.run("modal-variant", rule, {
       code:   `import { Modal } from '@patternfly/react-core'; <Modal isLarge />`,
       output: `import { Modal } from '@patternfly/react-core'; <Modal variant="large" />`,
       errors: [{
-        message: `Modal has replaced isLarge prop with variant="large"`,
+        message: `isLarge prop for Modal has been replaced with variant="large"`,
         type: "JSXOpeningElement",
       }]
     },
@@ -24,7 +24,7 @@ ruleTester.run("modal-variant", rule, {
       code:   `import { Modal } from '@patternfly/react-core'; <Modal isSmall />`,
       output: `import { Modal } from '@patternfly/react-core'; <Modal variant="small" />`,
       errors: [{
-        message: `Modal has replaced isSmall prop with variant="small"`,
+        message: `isSmall prop for Modal has been replaced with variant="small"`,
         type: "JSXOpeningElement",
       }]
     }

--- a/packages/eslint-plugin-pf-codemods/test/rules/v4/page-header-prop-rename.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v4/page-header-prop-rename.js
@@ -15,7 +15,7 @@ ruleTester.run("page-header-prop-rename", rule, {
       code:   `import { PageHeader } from '@patternfly/react-core'; <PageHeader toolbar="tools" />`,
       output: `import { PageHeader } from '@patternfly/react-core'; <PageHeader headerTools="tools" />`,
       errors: [{
-        message: `toolbar prop has been removed from PageHeader. Use headerTools instead`,
+        message: `toolbar prop for PageHeader has been renamed to headerTools`,
         type: "JSXOpeningElement",
       }]
     },

--- a/packages/eslint-plugin-pf-codemods/test/rules/v4/remove-gutter-size.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v4/remove-gutter-size.js
@@ -16,7 +16,7 @@ ruleTester.run("remove-gutter-size", rule, {
       code:   `import { Gallery } from '@patternfly/react-core'; <Gallery gutter="sm" />`,
       output: `import { Gallery } from '@patternfly/react-core'; <Gallery hasGutter />`,
       errors: [{
-        message: "gutter prop has been removed for Gallery. Use hasGutter instead",
+        message: "gutter prop for Gallery has been replaced with hasGutter",
         type: "JSXOpeningElement",
       }]
     }

--- a/packages/eslint-plugin-pf-codemods/test/rules/v4/select-rename-isExpanded.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v4/select-rename-isExpanded.js
@@ -19,7 +19,7 @@ ruleTester.run("select-rename-isExpanded", rule, {
       code:   `import { Select } from '@patternfly/react-core'; <Select isExpanded />`,
       output: `import { Select } from '@patternfly/react-core'; <Select isOpen />`,
       errors: [{
-        message: "isExpanded has been renamed to isOpen for Select",
+        message: "isExpanded prop for Select has been renamed to isOpen",
         type: "JSXOpeningElement",
       }]
     },
@@ -28,7 +28,7 @@ ruleTester.run("select-rename-isExpanded", rule, {
       code:   `import { Select } from '@patternfly/react-core'; <Select isExpanded={myVar} />`,
       output: `import { Select } from '@patternfly/react-core'; <Select isOpen={myVar} />`,
       errors: [{
-        message: "isExpanded has been renamed to isOpen for Select",
+        message: "isExpanded prop for Select has been renamed to isOpen",
         type: "JSXOpeningElement",
       }]
     }

--- a/packages/eslint-plugin-pf-codemods/test/rules/v4/skip-to-content-remove-component.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v4/skip-to-content-remove-component.js
@@ -12,7 +12,7 @@ ruleTester.run("skip-to-content-remove-component", rule, {
       code:   `import { SkipToContent } from '@patternfly/react-core'; <SkipToContent component="h1" />`,
       output: `import { SkipToContent } from '@patternfly/react-core'; <SkipToContent  />`,
       errors: [{
-        message: `Component prop was removed from SkipToContent in favor of always using an anchor tag`,
+        message: `component prop was removed from SkipToContent in favor of always using an anchor tag`,
         type: "JSXOpeningElement",
       }]
     },

--- a/packages/eslint-plugin-pf-codemods/test/rules/v4/wizard-rename-text.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v4/wizard-rename-text.js
@@ -16,7 +16,7 @@ ruleTester.run("wizard-rename-text", rule, {
       code:   `import { WizardNavItem } from '@patternfly/react-core'; <WizardNavItem text="sm" />`,
       output: `import { WizardNavItem } from '@patternfly/react-core'; <WizardNavItem content="sm" />`,
       errors: [{
-        message: "text prop has been removed for WizardNavItem. Use content instead",
+        message: "text prop for WizardNavItem has been renamed to content",
         type: "JSXOpeningElement",
       }]
     }

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/alert-remove-titleHeadingLevel.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/alert-remove-titleHeadingLevel.js
@@ -16,7 +16,7 @@ ruleTester.run("alert-remove-titleHeadingLevel", rule, {
       code:   `import { Alert } from '@patternfly/react-core'; <Alert titleHeadingLevel />`,
       output: `import { Alert } from '@patternfly/react-core'; <Alert component />`,
       errors: [{
-        message: `titleHeadingLevel prop has been removed for Alert and replaced with the component prop.`,
+        message: `titleHeadingLevel prop for Alert has been renamed to component`,
         type: "JSXOpeningElement",
       }]
     },

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/alert-remove-titleHeadingLevel.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/alert-remove-titleHeadingLevel.js
@@ -24,7 +24,7 @@ ruleTester.run("alert-remove-titleHeadingLevel", rule, {
       code:   `import { Alert } from '@patternfly/react-core/dist/esm/components/Accordion/index.js'; <Alert titleHeadingLevel />`,
       output: `import { Alert } from '@patternfly/react-core/dist/esm/components/Accordion/index.js'; <Alert component />`,
       errors: [{
-        message: `titleHeadingLevel prop has been removed for Alert and replaced with the component prop.`,
+        message: `titleHeadingLevel prop for Alert has been renamed to component`,
         type: "JSXOpeningElement",
       }]
     }

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/button-remove-isSmallisLarge.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/button-remove-isSmallisLarge.js
@@ -35,7 +35,7 @@ ruleTester.run("button-remove-isSmallisLarge", rule, {
       code:   `import { Button } from '@patternfly/react-core/dist/esm/components/Button/index.js'; <Button isSmall />`,
       output: `import { Button } from '@patternfly/react-core/dist/esm/components/Button/index.js'; <Button size="sm" />`,
       errors: [{
-        message: `isSmall prop for Button has been renamed to size="sm"`,
+        message: `use size="sm" instead of isSmall prop for Button`,
         type: "JSXOpeningElement",
       }]
     },
@@ -43,7 +43,7 @@ ruleTester.run("button-remove-isSmallisLarge", rule, {
       code:   `import { Button } from '@patternfly/react-core/dist/esm/components/Button/index.js'; <Button isLarge />`,
       output: `import { Button } from '@patternfly/react-core/dist/esm/components/Button/index.js'; <Button size="lg" />`,
       errors: [{
-        message: `isLarge prop for Button has been renamed to size="lg"`,
+        message: `use size="lg" instead of isLarge prop for Button`,
         type: "JSXOpeningElement",
       }]
     }

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/button-remove-isSmallisLarge.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/button-remove-isSmallisLarge.js
@@ -16,10 +16,10 @@ ruleTester.run("button-remove-isSmallisLarge", rule, {
   ],
   invalid: [
     {
-      code:   `import { Button } from '@patternfly/react-core'; <Button isSmall />`,
+      code:   `import { Button } from '@patternfly/react-core'; <Button isSmall={true} />`,
       output: `import { Button } from '@patternfly/react-core'; <Button size="sm" />`,
       errors: [{
-        message: `isSmall prop for Button has been renamed to size="sm"`,
+        message: `use size="sm" instead of isSmall prop for Button`,
         type: "JSXOpeningElement",
       }]
     },
@@ -27,7 +27,7 @@ ruleTester.run("button-remove-isSmallisLarge", rule, {
       code:   `import { Button } from '@patternfly/react-core'; <Button isLarge />`,
       output: `import { Button } from '@patternfly/react-core'; <Button size="lg" />`,
       errors: [{
-        message: `isLarge prop for Button has been renamed to size="lg"`,
+        message: `use size="lg" instead of isLarge prop for Button`,
         type: "JSXOpeningElement",
       }]
     },

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/clipboardCopy-remove-switchDelay.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/clipboardCopy-remove-switchDelay.js
@@ -27,7 +27,7 @@ ruleTester.run("clipboardCopy-remove-switchDelay", rule, {
       code:   `import { ClipboardCopy } from '@patternfly/react-core/dist/esm/components/Clipboard/index.js'; <ClipboardCopy switchDelay />`,
       output: `import { ClipboardCopy } from '@patternfly/react-core/dist/esm/components/Clipboard/index.js'; <ClipboardCopy  />`,
       errors: [{
-        message: `switchDelay prop has been removed for ClipboardCopy`,
+        message: `switchDelay prop for ClipboardCopy has been removed`,
         type: "JSXOpeningElement",
       }]
     }

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/clipboardCopy-remove-switchDelay.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/clipboardCopy-remove-switchDelay.js
@@ -19,7 +19,7 @@ ruleTester.run("clipboardCopy-remove-switchDelay", rule, {
       code:   `import { ClipboardCopy } from '@patternfly/react-core'; <ClipboardCopy switchDelay />`,
       output: `import { ClipboardCopy } from '@patternfly/react-core'; <ClipboardCopy  />`,
       errors: [{
-        message: `switchDelay prop has been removed for ClipboardCopy`,
+        message: `switchDelay prop for ClipboardCopy has been removed`,
         type: "JSXOpeningElement",
       }]
     },

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/datalist-remove-props.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/datalist-remove-props.js
@@ -39,7 +39,7 @@ ruleTester.run("datalist-remove-props", rule, {
       code:   `import { DataList } from '@patternfly/react-core'; <DataList itemOrder />`,
       output: `import { DataList } from '@patternfly/react-core'; <DataList  />`,
       errors: [{
-        message: `itemOrder prop for DataList has been removed.`,
+        message: `itemOrder prop for DataList has been removed`,
         type: "JSXOpeningElement",
       }]
     }

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/dropdownItem-remove-isHovered.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/dropdownItem-remove-isHovered.js
@@ -27,7 +27,7 @@ ruleTester.run("dropdownItem-remove-isHovered", rule, {
       code:   `import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/index.js'; <DropdownItem isHovered />`,
       output: `import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/index.js'; <DropdownItem  />`,
       errors: [{
-        message: `isHovered prop has been removed for DropdownItem.`,
+        message: `isHovered prop for DropdownItem has been removed`,
         type: "JSXOpeningElement",
       }]
     }

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/dropdownItem-remove-isHovered.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/dropdownItem-remove-isHovered.js
@@ -19,7 +19,7 @@ ruleTester.run("dropdownItem-remove-isHovered", rule, {
       code:   `import { DropdownItem } from '@patternfly/react-core'; <DropdownItem isHovered />`,
       output: `import { DropdownItem } from '@patternfly/react-core'; <DropdownItem  />`,
       errors: [{
-        message: `isHovered prop has been removed for DropdownItem.`,
+        message: `isHovered prop for DropdownItem has been removed`,
         type: "JSXOpeningElement",
       }]
     },

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/dropdownMenu-remove-openedOnEnter.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/dropdownMenu-remove-openedOnEnter.js
@@ -19,7 +19,7 @@ ruleTester.run("dropdownMenu-remove-openedOnEnter", rule, {
       code:   `import { DropdownMenu } from '@patternfly/react-core/dist/esm/components/Dropdown/index.js'; <DropdownMenu openedOnEnter={false} />`,
       output: `import { DropdownMenu } from '@patternfly/react-core/dist/esm/components/Dropdown/index.js'; <DropdownMenu  />`,
       errors: [{
-        message: `openedOnEnter prop for DropdownMenu has been removed.`,
+        message: `openedOnEnter prop for DropdownMenu has been removed`,
         type: "JSXOpeningElement",
       }]
     },

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/dropdownMenu-remove-openedOnEnter.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/dropdownMenu-remove-openedOnEnter.js
@@ -27,7 +27,7 @@ ruleTester.run("dropdownMenu-remove-openedOnEnter", rule, {
       code:   `import { DropdownMenu } from '@patternfly/react-core'; <DropdownMenu openedOnEnter={false} />`,
       output: `import { DropdownMenu } from '@patternfly/react-core'; <DropdownMenu  />`,
       errors: [{
-        message: `openedOnEnter prop for DropdownMenu has been removed.`,
+        message: `openedOnEnter prop for DropdownMenu has been removed`,
         type: "JSXOpeningElement",
       }]
     }

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/overflowMenuDropdownItem-renamed-prop.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/overflowMenuDropdownItem-renamed-prop.js
@@ -40,7 +40,7 @@ ruleTester.run("overflowMenuDropdownItem-renamed-prop", rule, {
       output: `import { OverflowMenuDropdownItem as OMDropdownItem } from '@patternfly/react-core/dist/esm/components/OverflowMenu/index.js'; <OMDropdownItem itemId={0} />`,
       errors: [
         {
-          message: `The "index" prop for OMDropdownItem has been renamed to "itemId", and its type has been updated to either a number or string.`,
+          message: `the "index" prop for OMDropdownItem has been renamed to "itemId", and its type has been updated to either a number or string.`,
           type: "JSXOpeningElement",
         },
       ],

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/overflowMenuDropdownItem-renamed-prop.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/overflowMenuDropdownItem-renamed-prop.js
@@ -20,7 +20,7 @@ ruleTester.run("overflowMenuDropdownItem-renamed-prop", rule, {
       output: `import { OverflowMenuDropdownItem } from '@patternfly/react-core'; <OverflowMenuDropdownItem itemId={0} />`,
       errors: [
         {
-          message: `The "index" prop for OverflowMenuDropdownItem has been renamed to "itemId", and its type has been updated to either a number or string.`,
+          message: `the "index" prop for OverflowMenuDropdownItem has been renamed to "itemId", and its type has been updated to either a number or string.`,
           type: "JSXOpeningElement",
         },
       ],
@@ -30,7 +30,7 @@ ruleTester.run("overflowMenuDropdownItem-renamed-prop", rule, {
       output: `import { OverflowMenuDropdownItem as OMDropdownItem } from '@patternfly/react-core'; <OMDropdownItem itemId={0} />`,
       errors: [
         {
-          message: `The "index" prop for OMDropdownItem has been renamed to "itemId", and its type has been updated to either a number or string.`,
+          message: `the "index" prop for OMDropdownItem has been renamed to "itemId", and its type has been updated to either a number or string.`,
           type: "JSXOpeningElement",
         },
       ],

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/popper-remove-popperMatchesTriggerWidth.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/popper-remove-popperMatchesTriggerWidth.js
@@ -27,7 +27,7 @@ ruleTester.run("popper-remove-popperMatchesTriggerWidth", rule, {
       code:   `import { Popper } from '@patternfly/react-core/dist/esm/components/Popover/index.js'; <Popper popperMatchesTriggerWidth />`,
       output: `import { Popper } from '@patternfly/react-core/dist/esm/components/Popover/index.js'; <Popper  />`,
       errors: [{
-        message: `popperMatchesTriggerWidth prop has been removed for Popper.  The width can instead be modified via the new minWidth, maxWidth, and width properties`,
+        message: `popperMatchesTriggerWidth prop has been removed for Popper. The width can instead be modified via the new minWidth, maxWidth, and width properties`,
         type: "JSXOpeningElement",
       }]
     }

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/popper-remove-popperMatchesTriggerWidth.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/popper-remove-popperMatchesTriggerWidth.js
@@ -19,7 +19,7 @@ ruleTester.run("popper-remove-popperMatchesTriggerWidth", rule, {
       code:   `import { Popper } from '@patternfly/react-core'; <Popper popperMatchesTriggerWidth />`,
       output: `import { Popper } from '@patternfly/react-core'; <Popper  />`,
       errors: [{
-        message: `popperMatchesTriggerWidth prop has been removed for Popper.  The width can instead be modified via the new minWidth, maxWidth, and width properties`,
+        message: `popperMatchesTriggerWidth prop has been removed for Popper. The width can instead be modified via the new minWidth, maxWidth, and width properties`,
         type: "JSXOpeningElement",
       }]
     },

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/simpleList-remove-isCurrent.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/simpleList-remove-isCurrent.js
@@ -27,7 +27,7 @@ ruleTester.run("simpleList-remove-isCurrent", rule, {
       code:   `import { SimpleList } from '@patternfly/react-core/dist/esm/components/SimpleList/index.js'; <SimpleList isCurrent />`,
       output: `import { SimpleList } from '@patternfly/react-core/dist/esm/components/SimpleList/index.js'; <SimpleList isActive />`,
       errors: [{
-        message: `isCurrent prop has been removed for SimpleList and replaced with the isActive prop.`,
+        message: `isCurrent prop for SimpleList has been renamed to isActive`,
         type: "JSXOpeningElement",
       }]
     },

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/simpleList-remove-isCurrent.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/simpleList-remove-isCurrent.js
@@ -19,7 +19,7 @@ ruleTester.run("simpleList-remove-isCurrent", rule, {
       code:   `import { SimpleList } from '@patternfly/react-core'; <SimpleList isCurrent />`,
       output: `import { SimpleList } from '@patternfly/react-core'; <SimpleList isActive />`,
       errors: [{
-        message: `isCurrent prop has been removed for SimpleList and replaced with the isActive prop.`,
+        message: `isCurrent prop for SimpleList has been renamed to isActive`,
         type: "JSXOpeningElement",
       }]
     },

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/tabs-remove-hasSecondaryBorderBottom.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/tabs-remove-hasSecondaryBorderBottom.js
@@ -20,7 +20,7 @@ ruleTester.run("tabs-remove-hasSecondaryBorderBottom", rule, {
       output: `import { Tabs } from '@patternfly/react-core'; <Tabs  />`,
       errors: [
         {
-          message: `hasSecondaryBorderBottom prop has been removed for Tabs.`,
+          message: `hasSecondaryBorderBottom prop for Tabs has been removed`,
           type: "JSXOpeningElement",
         },
       ],

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/tabs-remove-hasSecondaryBorderBottom.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/tabs-remove-hasSecondaryBorderBottom.js
@@ -30,7 +30,7 @@ ruleTester.run("tabs-remove-hasSecondaryBorderBottom", rule, {
       output: `import { Tabs } from '@patternfly/react-core/dist/esm/components/Tabs/index.js'; <Tabs  />`,
       errors: [
         {
-          message: `hasSecondaryBorderBottom prop has been removed for Tabs.`,
+          message: `hasSecondaryBorderBottom prop for Tabs has been removed`,
           type: "JSXOpeningElement",
         },
       ],

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/toolbar-remove-visiblity.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/toolbar-remove-visiblity.js
@@ -19,7 +19,7 @@ ruleTester.run("toolbar-remove-visiblity", rule, {
       code:   `import { ToolbarContent } from '@patternfly/react-core'; <ToolbarContent visiblity={{ default: 'hidden'}} />`,
       output: `import { ToolbarContent } from '@patternfly/react-core'; <ToolbarContent visibility={{ default: 'hidden'}} />`,
       errors: [{
-        message: `visiblity prop for ToolbarContent has been removed and replaced with the visibility prop.`,
+        message: `visiblity prop for ToolbarContent has been renamed to visibility`,
         type: "JSXOpeningElement",
       }]
     },

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/toolbar-remove-visiblity.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/toolbar-remove-visiblity.js
@@ -27,7 +27,7 @@ ruleTester.run("toolbar-remove-visiblity", rule, {
       code:   `import { ToolbarContent } from '@patternfly/react-core/dist/esm/components/ToolbarContent/index.js'; <ToolbarContent visiblity={{ default: 'hidden'}} />`,
       output: `import { ToolbarContent } from '@patternfly/react-core/dist/esm/components/ToolbarContent/index.js'; <ToolbarContent visibility={{ default: 'hidden'}} />`,
       errors: [{
-        message: `visiblity prop for ToolbarContent has been removed and replaced with the visibility prop.`,
+        message: `visiblity prop for ToolbarContent has been renamed to visibility`,
         type: "JSXOpeningElement",
       }]
     }

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -87,7 +87,11 @@ import { Td } from "@patternfly/react-table";
 const tdSelectTypeObj = {"disable": true};
 
 //following type of import was causing errors for rules that checked specifiers before import package
+<<<<<<< HEAD
 import foo from 'Bar';
+=======
+import foo from "Bar";
+>>>>>>> a38c86f (fix(renameProps): fix potentially wrong usages of renameProps)
 
 //eslint-disable-next-line @typescript/foo
 

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -87,11 +87,7 @@ import { Td } from "@patternfly/react-table";
 const tdSelectTypeObj = {"disable": true};
 
 //following type of import was causing errors for rules that checked specifiers before import package
-<<<<<<< HEAD
 import foo from 'Bar';
-=======
-import foo from "Bar";
->>>>>>> a38c86f (fix(renameProps): fix potentially wrong usages of renameProps)
 
 //eslint-disable-next-line @typescript/foo
 


### PR DESCRIPTION
- getting rid of the `renameProp` helper completely
- `renameProps` now accepts more parameters for each prop to modify
    - `newName`: new prop name
    - `message`: custom message, can be a string or a function accepting `node` - this is good for printing out the local node name, when using aliased imports
    - `replace`: indicates, that the whole prop should be replaced. There were lots of "not so correct" usages of the renameProps helper, where the whole prop has been replaced (e.g. `withToolBar` -> `categoryName="pf-codemod-category"`), but it previously worked in a way, that only the prop name was changed, so if there would be some code like `withToolBar={true}`, it would lead to `categoryName="pf-codemod-category"={true}`, that is why the replace prop is introduced
    - prop can still accept just a string as a new prop name, to keep backwards compatibility and keeping the simple usage, when there is no need for custom `message` or `replace` option
- whole structure of the `renames` object passed to `renameProps` is described in a docstring above the function