### PR TITLE
fix(EmptyState): updated codemod for renaming actions

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/emptyState-rename-components.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/emptyState-rename-components.js
@@ -1,4 +1,8 @@
-const { ensureImports, getPackageImports, pfPackageMatches } = require("../../helpers");
+const {
+  ensureImports,
+  getPackageImports,
+  pfPackageMatches,
+} = require("../../helpers");
 
 // https://github.com/patternfly/patternfly-react/pull/8737
 module.exports = {
@@ -24,40 +28,6 @@ module.exports = {
             if (!pfPackageMatches(pfPackage, node.source.value)) {
               return;
             }
-
-            const allTokens = context
-              .getSourceCode()
-              .ast.body.filter((node) => node.type !== "ImportDeclaration")
-              .map((node) =>
-                context
-                  .getSourceCode()
-                  .getTokens(node)
-                  .map((token) => token.value)
-              )
-              .reduce((acc, val) => acc.concat(val), []);
-
-            imports
-              .filter((spec) => !allTokens.includes(spec.local.name))
-              .forEach((spec) =>
-                context.report({
-                  node,
-                  message: `unused patternfly import ${spec.local.name}`,
-                  fix(fixer) {
-                    const getEndRange = () => {
-                      const nextComma = context
-                        .getSourceCode()
-                        .getTokenAfter(spec);
-
-                      return context.getSourceCode().getText(nextComma) === ","
-                        ? context.getSourceCode().getTokenAfter(nextComma)
-                            .range[0]
-                        : spec.range[1];
-                    };
-
-                    return fixer.removeRange([spec.range[0], getEndRange()]);
-                  },
-                })
-              );
 
             ensureImports(context, node, pfPackage, [newName]);
           },

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/emptyState-rename-components.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/emptyState-rename-components.js
@@ -58,16 +58,6 @@ ruleTester.run("emptyState-rename-components", rule, {
         },
       ],
     },
-    { // after second run of the rule
-      code: `import { EmptyStateSecondaryActions, EmptyStateActions } from '@patternfly/react-core'; <EmptyStateActions>Other actions</EmptyStateActions>`,
-      output: `import { EmptyStateActions } from '@patternfly/react-core'; <EmptyStateActions>Other actions</EmptyStateActions>`,
-      errors: [
-        {
-          message: "unused patternfly import EmptyStateSecondaryActions",
-          type: "ImportDeclaration",
-        },
-      ],
-    },
     {
       code: `import { EmptyStatePrimary } from '@patternfly/react-core'; <EmptyStatePrimary>Primary action</EmptyStatePrimary>`,
       output: `import { EmptyStatePrimary, EmptyStateActions } from '@patternfly/react-core'; <EmptyStateActions>Primary action</EmptyStateActions>`,
@@ -80,16 +70,6 @@ ruleTester.run("emptyState-rename-components", rule, {
         {
           message: "EmptyStatePrimary has been replaced with EmptyStateActions",
           type: "JSXElement",
-        },
-      ],
-    },
-    { // after second run of the rule
-      code: `import { EmptyStatePrimary, EmptyStateActions } from '@patternfly/react-core'; <EmptyStateActions>Primary action</EmptyStateActions>`,
-      output: `import { EmptyStateActions } from '@patternfly/react-core'; <EmptyStateActions>Primary action</EmptyStateActions>`,
-      errors: [
-        {
-          message: "unused patternfly import EmptyStatePrimary",
-          type: "ImportDeclaration",
         },
       ],
     },
@@ -108,17 +88,6 @@ ruleTester.run("emptyState-rename-components", rule, {
         },
       ],
     },
-    { // after second run of the rule
-      code: `import { EmptyStatePrimary as Primary, EmptyStateActions } from '@patternfly/react-core'; <EmptyStateActions>Primary action</EmptyStateActions>`,
-      output: `import { EmptyStateActions } from '@patternfly/react-core'; <EmptyStateActions>Primary action</EmptyStateActions>`,
-      errors: [
-        {
-          message:
-            "unused patternfly import Primary",
-          type: "ImportDeclaration",
-        },
-      ],
-    },
     {
       code: `import { EmptyStatePrimary, EmptyStateSecondaryActions } from '@patternfly/react-core';
       <>
@@ -132,7 +101,8 @@ ruleTester.run("emptyState-rename-components", rule, {
       </>`,
       errors: [
         {
-          message: "add missing imports EmptyStateActions from @patternfly/react-core",
+          message:
+            "add missing imports EmptyStateActions from @patternfly/react-core",
           type: "ImportDeclaration",
         },
         {
@@ -159,7 +129,8 @@ ruleTester.run("emptyState-rename-components", rule, {
       </>`,
       errors: [
         {
-          message: "add missing imports EmptyStateActions from @patternfly/react-core/dist/esm/components/EmptyState/index.js",
+          message:
+            "add missing imports EmptyStateActions from @patternfly/react-core/dist/esm/components/EmptyState/index.js",
           type: "ImportDeclaration",
         },
         {
@@ -170,64 +141,6 @@ ruleTester.run("emptyState-rename-components", rule, {
           message:
             "EmptyStateSecondaryActions has been replaced with EmptyStateActions",
           type: "JSXElement",
-        },
-      ],
-    },
-    { // after second run of the rule
-      code: `import { EmptyStatePrimary, EmptyStateSecondaryActions, EmptyStateActions } from '@patternfly/react-core';
-      <>
-        <EmptyStateActions>Primary action</EmptyStateActions>
-        <EmptyStateActions>Secondary</EmptyStateActions>
-      </>`,
-      output: `import { EmptyStateSecondaryActions, EmptyStateActions } from '@patternfly/react-core';
-      <>
-        <EmptyStateActions>Primary action</EmptyStateActions>
-        <EmptyStateActions>Secondary</EmptyStateActions>
-      </>`,
-      errors: [
-        {
-          message: "unused patternfly import EmptyStatePrimary",
-          type: "ImportDeclaration",
-        },
-        {
-          message: "unused patternfly import EmptyStateSecondaryActions",
-          type: "ImportDeclaration",
-        },
-      ],
-    },
-    { // after third run of the rule
-      code: `import { EmptyStateSecondaryActions, EmptyStateActions } from '@patternfly/react-core';
-      <>
-        <EmptyStateActions>Primary action</EmptyStateActions>
-        <EmptyStateActions>Secondary</EmptyStateActions>
-      </>`,
-      output: `import { EmptyStateActions } from '@patternfly/react-core';
-      <>
-        <EmptyStateActions>Primary action</EmptyStateActions>
-        <EmptyStateActions>Secondary</EmptyStateActions>
-      </>`,
-      errors: [
-        {
-          message: "unused patternfly import EmptyStateSecondaryActions",
-          type: "ImportDeclaration",
-        },
-      ],
-    },
-    {
-      code: `import { EmptyStateSecondaryActions, EmptyStateActions } from '@patternfly/react-core/dist/esm/components/EmptyState/index.js';
-      <>
-        <EmptyStateActions>Primary action</EmptyStateActions>
-        <EmptyStateActions>Secondary</EmptyStateActions>
-      </>`,
-      output: `import { EmptyStateActions } from '@patternfly/react-core/dist/esm/components/EmptyState/index.js';
-      <>
-        <EmptyStateActions>Primary action</EmptyStateActions>
-        <EmptyStateActions>Secondary</EmptyStateActions>
-      </>`,
-      errors: [
-        {
-          message: "unused patternfly import EmptyStateSecondaryActions",
-          type: "ImportDeclaration",
         },
       ],
     },


### PR DESCRIPTION
Closes #369 

Simply removes some logic from the codemod to prevent the need for tests having to make multiple passes. The codemod itself won't remove unused imports, but since we have the new rule that runs on cleanup that should take care of things.