### PR TITLE
fix(Nav): added event param as first param

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/helpers.js
+++ b/packages/eslint-plugin-pf-codemods/lib/helpers.js
@@ -470,7 +470,12 @@ function ensureImports(context, node, package, imports) {
 
 // propMap structure: { propName: { defaultParamName: string, previousParamIndex?: number, otherMatchers?: /regex/ } | string }
 // example:           { onClick: { defaultParamName: '_event', previousParamIndex: 1, otherMatchers?: /^_?(ev\w*|e$)/ } }
-function addCallbackParam(componentsArray, propMap) {
+function addCallbackParam(
+  componentsArray,
+  propMap,
+  message = (propName, componentName, paramName) =>
+    `The "${propName}" prop for ${componentName} has been updated so that the "${paramName}" parameter is the first parameter. "${propName}" handlers may require an update.`
+) {
   return function (context) {
     const imports = [
       ...getPackageImports(context, "@patternfly/react-core"),
@@ -567,7 +572,11 @@ function addCallbackParam(componentsArray, propMap) {
                   else {
                     context.report({
                       node,
-                      message: `The "${attribute.name.name}" prop for ${node.name.name} has been updated so that the "${defaultParamName}" parameter is the first parameter. "${attribute.name.name}" handlers may require an update.`,
+                      message: message(
+                        attribute.name.name,
+                        node.name.name,
+                        defaultParamName
+                      ),
                     });
                     return;
                   }
@@ -580,7 +589,11 @@ function addCallbackParam(componentsArray, propMap) {
                 ) {
                   context.report({
                     node,
-                    message: `The "${attribute.name.name}" prop for ${node.name.name} has been updated so that the "${newParam}" parameter is the first parameter. "${attribute.name.name}" handlers may require an update.`,
+                    message: message(
+                      attribute.name.name,
+                      node.name.name,
+                      newParam
+                    ),
                     fix(fixer) {
                       const fixes = [];
 

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/nav-update-callbackParams.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/nav-update-callbackParams.js
@@ -1,0 +1,14 @@
+const { addCallbackParam } = require("../../helpers");
+
+// https://github.com/patternfly/patternfly-react/pull/8997
+module.exports = {
+  meta: { fixable: "code" },
+  create: addCallbackParam(
+    ["Nav"],
+    { onSelect: "_event", onToggle: "_event" },
+    (propName, componentName, paramName) =>
+      `The "${propName}" prop for ${componentName} has been updated so that the "${paramName}" parameter is the first parameter, and has been removed from the ${propName
+        .slice(2)
+        .toLowerCase()}edItem object parameter. "${propName}" handlers may require an update.`
+  ),
+};

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/nav-update-callbackParams.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/nav-update-callbackParams.js
@@ -1,0 +1,12 @@
+const { addCallbackParamTester } = require("../../testHelpers");
+
+addCallbackParamTester(
+  "nav-update-callbackParams",
+  "Nav",
+  ["onSelect", "onToggle"],
+  "_event",
+  (componentName, propName, newParamName) =>
+    `The "${propName}" prop for ${componentName} has been updated so that the "${newParamName}" parameter is the first parameter, and has been removed from the ${propName
+      .slice(2)
+      .toLowerCase()}edItem object parameter. "${propName}" handlers may require an update.`
+);

--- a/packages/eslint-plugin-pf-codemods/test/testHelpers.js
+++ b/packages/eslint-plugin-pf-codemods/test/testHelpers.js
@@ -277,14 +277,15 @@ function getInvalidSwapCallbackParamTests(
   componentNameArray,
   propNameArray,
   previousParamIndex,
-  newParamName
+  newParamName,
+  createMessageCallback
 ) {
   let tests = getInvalidAddCallbackParamTests(
     componentNameArray,
     propNameArray,
     newParamName,
     previousParamIndex,
-    getAddCallbackParamMessage
+    createMessageCallback
   );
 
   const formattedNewParamName =
@@ -386,7 +387,8 @@ function swapCallbackParamTester(
   componentNames,
   propNames,
   previousParamIndex,
-  newParamName = "_event"
+  newParamName = "_event",
+  createMessageCallback = getAddCallbackParamMessage
 ) {
   const rule = require(`../lib/rules/v5/${ruleName}`);
   const componentNameArray =
@@ -403,7 +405,8 @@ function swapCallbackParamTester(
       componentNameArray,
       propNameArray,
       previousParamIndex,
-      newParamName
+      newParamName,
+      createMessageCallback
     ),
   });
 }

--- a/packages/eslint-plugin-pf-codemods/test/testHelpers.js
+++ b/packages/eslint-plugin-pf-codemods/test/testHelpers.js
@@ -323,7 +323,7 @@ function getInvalidSwapCallbackParamTests(
             output: `import { ${componentName} } from '@patternfly/react-core'; function handler(${fixedArgs}) {}; <${componentName} ${propName}={handler} />;`,
             errors: [
               {
-                message: getAddCallbackParamMessage(
+                message: createMessageCallback(
                   componentName,
                   propName,
                   variation
@@ -337,7 +337,7 @@ function getInvalidSwapCallbackParamTests(
             output: `import { ${componentName} } from '@patternfly/react-core/dist/esm/components/${componentName}/index.js'; function handler(${fixedArgs}) {}; <${componentName} ${propName}={handler} />;`,
             errors: [
               {
-                message: getAddCallbackParamMessage(
+                message: createMessageCallback(
                   componentName,
                   propName,
                   variation

--- a/packages/eslint-plugin-pf-codemods/test/testHelpers.js
+++ b/packages/eslint-plugin-pf-codemods/test/testHelpers.js
@@ -47,7 +47,8 @@ function getInvalidAddCallbackParamTests(
   componentNameArray,
   propNameArray,
   newParamName,
-  previousParamIndex
+  previousParamIndex,
+  createMessageCallback
 ) {
   let tests = [];
 
@@ -58,7 +59,7 @@ function getInvalidAddCallbackParamTests(
         output: `import { ${componentName} } from '@patternfly/react-core'; <${componentName} ${propName}={(${newParamName}, id) => handler(id)} />;`,
         errors: [
           {
-            message: getAddCallbackParamMessage(
+            message: createMessageCallback(
               componentName,
               propName,
               newParamName
@@ -72,7 +73,7 @@ function getInvalidAddCallbackParamTests(
         output: `import { ${componentName} } from '@patternfly/react-core/dist/esm/components/${componentName}/index.js'; <${componentName} ${propName}={(${newParamName}, id) => handler(id)} />;`,
         errors: [
           {
-            message: getAddCallbackParamMessage(
+            message: createMessageCallback(
               componentName,
               propName,
               newParamName
@@ -86,7 +87,7 @@ function getInvalidAddCallbackParamTests(
         output: `import { ${componentName} } from '@patternfly/react-core'; <${componentName} ${propName}={(${newParamName}, id: bar) => handler(id)} />;`,
         errors: [
           {
-            message: getAddCallbackParamMessage(
+            message: createMessageCallback(
               componentName,
               propName,
               newParamName
@@ -100,7 +101,7 @@ function getInvalidAddCallbackParamTests(
         output: `import { ${componentName} } from '@patternfly/react-core'; <${componentName} ${propName}={(${newParamName}, id) => handler(id)} />;`,
         errors: [
           {
-            message: getAddCallbackParamMessage(
+            message: createMessageCallback(
               componentName,
               propName,
               newParamName
@@ -114,7 +115,7 @@ function getInvalidAddCallbackParamTests(
         output: `import { ${componentName} as ${componentName}Deprecated } from '@patternfly/react-core/deprecated'; const handler = (${newParamName}, id) => {}; <${componentName}Deprecated ${propName}={handler} />;`,
         errors: [
           {
-            message: getAddCallbackParamMessage(
+            message: createMessageCallback(
               componentName + "Deprecated",
               propName,
               newParamName
@@ -128,7 +129,7 @@ function getInvalidAddCallbackParamTests(
         output: `import { ${componentName} } from '@patternfly/react-core'; const handler = (${newParamName}, id: bar) => {}; <${componentName} ${propName}={handler} />;`,
         errors: [
           {
-            message: getAddCallbackParamMessage(
+            message: createMessageCallback(
               componentName,
               propName,
               newParamName
@@ -142,7 +143,7 @@ function getInvalidAddCallbackParamTests(
         output: `import { ${componentName} } from '@patternfly/react-core'; function handler(${newParamName}, id) {}; <${componentName} ${propName}={handler} />;`,
         errors: [
           {
-            message: getAddCallbackParamMessage(
+            message: createMessageCallback(
               componentName,
               propName,
               newParamName
@@ -156,7 +157,7 @@ function getInvalidAddCallbackParamTests(
         output: `import { ${componentName} } from '@patternfly/react-core'; function handler(${newParamName}, id: bar) {}; <${componentName} ${propName}={handler} />;`,
         errors: [
           {
-            message: getAddCallbackParamMessage(
+            message: createMessageCallback(
               componentName,
               propName,
               newParamName
@@ -170,7 +171,7 @@ function getInvalidAddCallbackParamTests(
         output: `import { ${componentName} } from '@patternfly/react-core'; <${componentName} ${propName}={this.handler} />;`,
         errors: [
           {
-            message: getAddCallbackParamMessage(
+            message: createMessageCallback(
               componentName,
               propName,
               newParamName
@@ -184,7 +185,7 @@ function getInvalidAddCallbackParamTests(
         output: `import { ${componentName} as PF${componentName} } from '@patternfly/react-core'; <PF${componentName} ${propName}={(${newParamName}, id) => handler(id)} />;`,
         errors: [
           {
-            message: getAddCallbackParamMessage(
+            message: createMessageCallback(
               `PF${componentName}`,
               propName,
               newParamName
@@ -198,7 +199,7 @@ function getInvalidAddCallbackParamTests(
         output: `import { ${componentName} as PF${componentName} } from '@patternfly/react-core'; <PF${componentName} ${propName}={(${newParamName}, id: bar) => handler(id)} />;`,
         errors: [
           {
-            message: getAddCallbackParamMessage(
+            message: createMessageCallback(
               `PF${componentName}`,
               propName,
               newParamName
@@ -215,7 +216,7 @@ function getInvalidAddCallbackParamTests(
           output: `import { ${componentName} } from '@patternfly/react-core'; <${componentName} ${propName}={(${newParamName}, id, text) => handler(id)} />;`,
           errors: [
             {
-              message: getAddCallbackParamMessage(
+              message: createMessageCallback(
                 componentName,
                 propName,
                 newParamName
@@ -229,7 +230,7 @@ function getInvalidAddCallbackParamTests(
           output: `import { ${componentName} } from '@patternfly/react-core'; const handler = (${newParamName}, id, text) => {}; <${componentName} ${propName}={handler} />;`,
           errors: [
             {
-              message: getAddCallbackParamMessage(
+              message: createMessageCallback(
                 componentName,
                 propName,
                 newParamName
@@ -243,7 +244,7 @@ function getInvalidAddCallbackParamTests(
           output: `import { ${componentName} } from '@patternfly/react-core'; function handler(${newParamName}, id, text) {}; <${componentName} ${propName}={handler} />;`,
           errors: [
             {
-              message: getAddCallbackParamMessage(
+              message: createMessageCallback(
                 componentName,
                 propName,
                 newParamName
@@ -257,7 +258,7 @@ function getInvalidAddCallbackParamTests(
           output: `import { ${componentName} as PF${componentName} } from '@patternfly/react-core'; <PF${componentName} ${propName}={(${newParamName}, id, text) => handler(id)} />;`,
           errors: [
             {
-              message: getAddCallbackParamMessage(
+              message: createMessageCallback(
                 `PF${componentName}`,
                 propName,
                 newParamName
@@ -282,7 +283,8 @@ function getInvalidSwapCallbackParamTests(
     componentNameArray,
     propNameArray,
     newParamName,
-    previousParamIndex
+    previousParamIndex,
+    getAddCallbackParamMessage
   );
 
   const formattedNewParamName =
@@ -355,7 +357,8 @@ function addCallbackParamTester(
   ruleName,
   componentNames,
   propNames,
-  newParamName = "_event"
+  newParamName = "_event",
+  createMessageCallback = getAddCallbackParamMessage
 ) {
   const rule = require(`../lib/rules/v5/${ruleName}`);
   const componentNameArray =
@@ -371,7 +374,9 @@ function addCallbackParamTester(
     invalid: getInvalidAddCallbackParamTests(
       componentNameArray,
       propNameArray,
-      newParamName
+      newParamName,
+      undefined,
+      createMessageCallback
     ),
   });
 }

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -1456,9 +1456,49 @@ function handler2(_event, id) {};
 <MultipleFileUpload onFileDrop={handler2} />
 ```
 
+### nav-update-callbackParams [(#8997)](https://github.com/patternfly/patternfly-react/pull/8997)
+
+We've updated the `onSelect` and `onToggle` props for Nav so that the `event` parameter is the first parameter, and have removed the event property from the `selectedItem` and `toggledItem` object parameters respectively. Handlers may require an update.
+
+#### Examples
+
+In:
+
+```jsx
+<Navigation onSelect={(id) => handler(id)} />
+const handler1 = (id) => {};
+<Navigation onSelect={handler1} />
+function handler2(id) {};
+<Navigation onSelect={handler2} />
+
+<Navigation onToggle={(id) => handler(id)} />
+const toggleHandler1 = (id) => {};
+<Navigation onToggle={toggleHandler1} />
+function toggleHandler2(id) {};
+<Navigation onToggle={toggleHandler2} />
+```
+
+Out:
+
+```jsx
+<Navigation onSelect={(_event, id) => handler(id)} />
+const handler1 = (_event, id) => {};
+<Navigation onSelect={handler1} />
+function handler2(_event, id) {};
+<Navigation onSelect={handler2} />
+
+<Navigation onToggle={(_event, id) => handler(id)} />
+const toggleHandler1 = (_event, id) => {};
+<Navigation onToggle={toggleHandler1} />
+function toggleHandler2(_event, id) {};
+<Navigation onToggle={toggleHandler2} />
+```
+
 ### nav-warn-flyouts-now-inline [(#8628)](https://github.com/patternfly/patternfly-react/pull/8628)
 
 The placement Nav flyouts in the DOM has been changed, if you have Nav elements with flyouts you may need to update some selectors or snapshots in your test suites. This rule will raise a warning, but will not make any changes.
+
+
 
 ### no-unused-imports-v5
 

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -183,9 +183,9 @@ const alertVariantOption = AlertVariant.default;
     onReadFinished={(fileHandle) => readFinishedHandler(fileHandle)}
     onReadStarted={(fileHandle) => readStartedHandler(fileHandle)}
   />
-  <FileUploadField onTextChange={bar => textHandler(bar)} />
+  <FileUploadField onTextChange={(bar) => textHandler(bar)} />
   <FormSelect onChange={(foo, event) => handler(foo, event)} />
-  <FrogIcon size="sm" color="green" noVerticalAlign />
+  <FrogIcon size='sm' color='green' noVerticalAlign />
   <KebabToggle onToggle={} />
   <Label />
   <Label isTruncated />
@@ -198,6 +198,7 @@ const alertVariantOption = AlertVariant.default;
   <MultipleFileUpload onFileDrop={(foo) => handler(foo)} />
   <Nav flyout={"menu"} />
   <Nav variant='horizontal-subnav' />
+  <Nav onSelect={(foo) => handler(foo)} onToggle={(foo) => handler(foo)} />
   <NotificationBadge isRead />
   <NotificationBadge isRead={false} />
   <NotificationBadge isRead={isRead} />
@@ -205,9 +206,9 @@ const alertVariantOption = AlertVariant.default;
   <OptionsMenu></OptionsMenu>
   <NumberInput allowEmptyInput />
   <OverflowMenuDropdownItem index={0} />
-  <Page onPageResize={({obj}) => handler({obj})} />
-  <PageGroup aria-label="tester" />
-  <PageNavigation aria-label="tester" />
+  <Page onPageResize={({ obj }) => handler({ obj })} />
+  <PageGroup aria-label='tester' />
+  <PageNavigation aria-label='tester' />
   <PageSidebar isNavOpen />
   <PageSidebar nav='Content' />
   <PageToggleButton isNavOpen onNavToggle />


### PR DESCRIPTION
Closes #430 

Decided to update some helpers so that a custom message can be passed. I then just passed a custom message to mention that the params have been updated, and that the event property was removed from the `_edItem` object param.