### PR TITLE
feat(Datalist): provide fixer for selectableRow prop

### DIFF
--- a/packages/eslint-plugin-pf-codemods/index.js
+++ b/packages/eslint-plugin-pf-codemods/index.js
@@ -35,6 +35,7 @@ const setupRules = [
   "applicationLauncher-deprecated",
   "contextSelector-update-deprecatedPath",
   "dropdown-update-deprecatedPath",
+  "datalist-remove-selectableRow",
   "optionsMenu-deprecated",
   "pageHeader-deprecated",
   "select-deprecated",

--- a/packages/eslint-plugin-pf-codemods/lib/helpers.js
+++ b/packages/eslint-plugin-pf-codemods/lib/helpers.js
@@ -817,6 +817,19 @@ function getAllJSXElements(context) {
   return jsxElements;
 }
 
+function findVariableDeclaration(name, scope) {
+  while (scope !== null) {
+    const variable = scope.variables.find((v) => v.name === name);
+
+    if (variable) {
+      return variable;
+    }
+
+    scope = scope.upper;
+  }
+  return undefined;
+}
+
 module.exports = {
   createAliasImportSpecifiers,
   ensureImports,
@@ -829,4 +842,5 @@ module.exports = {
   splitSpecifiers,
   addCallbackParam,
   getAllJSXElements,
+  findVariableDeclaration,
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/dataList-onSelectableRowChange-updated-callback.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/dataList-onSelectableRowChange-updated-callback.js
@@ -1,0 +1,7 @@
+const { addCallbackParam } = require("../../helpers");
+
+// https://github.com/patternfly/patternfly-react/pull/8827
+module.exports = {
+  meta: { fixable: "code" },
+  create: addCallbackParam(["DataList"], { onSelectableRowChange: { defaultParamName: "_event", previousParamIndex: 1, otherMatchers: /^_?(ev\w*|e$)/ } }),
+};

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/datalist-remove-selectableRow.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/datalist-remove-selectableRow.js
@@ -27,19 +27,7 @@ module.exports = {
     const handleObjectExpression = (expr, toReplace) => {
       const propVal = getObjectProp(expr, "onChange")?.value;
 
-      if (!propVal) {
-        return;
-      }
-
-      if (propVal.type === "Identifier") {
-        toReplace.push([expr, sourceCode.getText(propVal)]);
-        handleIdentifierOfFunction(propVal, toReplace);
-      } else if (
-        ["ArrowFunctionExpression", "FunctionExpression"].includes(
-          propVal.type
-        ) &&
-        [1, 2].includes(propVal.params.length)
-      ) {
+      if (propVal) {
         toReplace.push([expr, sourceCode.getText(propVal)]);
       }
     };
@@ -72,7 +60,6 @@ module.exports = {
             variable?.defs[0].node.parent.range[0]
           );
           toReplace.push([n, sourceCode.getText(n.object)]);
-          handleRightAssignmentSide_Function(n.parent.right, toReplace);
         } else if (
           n.type === "AssignmentExpression" &&
           n.left.name === identifier.name
@@ -84,40 +71,6 @@ module.exports = {
       const variableValue = variable?.defs[0].node.init;
       variableValue &&
         handleRightAssignmentSide_Object(variableValue, toReplace);
-    };
-
-    const handleRightAssignmentSide_Function = (node, toReplace) => {
-      if (node.type === "Identifier") {
-        handleIdentifierOfFunction(node, toReplace);
-      }
-    };
-
-    const handleIdentifierOfFunction = (identifier, toReplace) => {
-      const variable = findVariableDeclaration(
-        identifier.name,
-        sourceCode.getScope(identifier)
-      );
-
-      const variableType = variable?.defs[0].type;
-      const variableNode = variable?.defs[0].node;
-
-      if (variableType === "Variable") {
-        const nodesUsingVariable = variable.references.map(
-          (ref) => ref.identifier.parent
-        );
-
-        nodesUsingVariable.forEach((n) => {
-          if (
-            n.type === "AssignmentExpression" &&
-            n.left.name === identifier.name
-          ) {
-            handleRightAssignmentSide_Function(n.right, toReplace);
-          }
-        });
-
-        variableNode.init &&
-          handleRightAssignmentSide_Function(variableNode.init, toReplace);
-      }
     };
 
     return {

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/datalist-remove-selectableRow.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/datalist-remove-selectableRow.js
@@ -149,27 +149,13 @@ module.exports = {
 
         toReplace.push([selectableRowAttr.name, "onSelectableRowChange"]);
 
-        // Having the same fix more than once would lead to errors
-        let toReplaceUnique = [];
-
-        for (const [oldVal, newVal] of toReplace) {
-          if (
-            toReplaceUnique.every(
-              ([oldUnique, newUnique]) =>
-                oldUnique !== oldVal || newUnique !== newVal
-            )
-          ) {
-            toReplaceUnique.push([oldVal, newVal]);
-          }
-        }
-
-        toReplaceUnique.length &&
+        toReplace.length &&
           context.report({
             message: `DataList's selectableRow property has been replaced with onSelectableRowChange. The order of the params in the callback has also been updated so that the event param is first.`,
             node,
             fix: function (fixer) {
               return [
-                ...toReplaceUnique.map(([oldValue, newValue]) =>
+                ...toReplace.map(([oldValue, newValue]) =>
                   fixer.replaceText(oldValue, newValue)
                 ),
                 ...[...new Set(rangeStartsToReplaceConst)].map((rangeStart) =>

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/datalist-remove-selectableRow.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/datalist-remove-selectableRow.js
@@ -1,25 +1,244 @@
-const { getFromPackage} = require('../../helpers');
+const {
+  getFromPackage,
+  findVariableDeclaration,
+  getAllJSXElements,
+} = require("../../helpers");
 
 //https://github.com/patternfly/patternfly-react/pull/8827
 module.exports = {
-  meta: {},
+  meta: { fixable: "code" },
   create: function (context) {
-    const dataListImport =  getFromPackage(context, '@patternfly/react-core')
-      .imports.filter(specifier => specifier.imported.name == 'DataList');
+    const dataListImport = getFromPackage(
+      context,
+      "@patternfly/react-core"
+    ).find((specifier) => specifier.imported.name == "DataList");
 
-    return dataListImport.length === 0 ? {} : {
-      JSXOpeningElement(node) {
-        if (dataListImport.map(imp => imp.local.name).includes(node.name.name)) {
-          const selectableRow = node.attributes.find(a => a.name?.name === 'selectableRow');
-          if (selectableRow) {
-            context.report({
-              node,
-              message: `DataList's selectableRow property has been replaced with onSelectableRowChange. The order of the params in the callback has also been updated so that the event param is first.`,
-            });
-          }
+    if (!dataListImport) {
+      return {};
+    }
+
+    let rangeStartsToReplaceConst = [];
+
+    const sc = context.getSourceCode();
+
+    const getObjectProp = (expr, propName) =>
+      expr.properties.find(
+        (prop) =>
+          (prop.key.type === "Identifier" && prop.key.name === propName) ||
+          (prop.key.type === "Literal" && prop.key.value === propName)
+      );
+
+    const swapCallbackParam = (params, toReplace) => {
+      if (params.length === 1) {
+        toReplace.push([params[0], `event, ${sc.getText(params[0])}`]);
+      } else if (params.length === 2) {
+        toReplace.push(
+          [params[0], sc.getText(params[1])],
+          [params[1], sc.getText(params[0])]
+        );
+      }
+    };
+
+    const handleObjectExpression = (expr, toReplace) => {
+      const propVal = getObjectProp(expr, "onChange")?.value;
+
+      if (!propVal) {
+        return;
+      }
+
+      if (propVal.type === "Identifier") {
+        toReplace.push([expr, sc.getText(propVal)]);
+        handleIdentifierOfFunction(propVal, toReplace);
+      } else if (propVal.type === "ArrowFunctionExpression") {
+        const paramsLen = propVal.params.length;
+        if (1 <= paramsLen <= 2) {
+          toReplace.push([
+            expr,
+            `(${
+              paramsLen === 1 ? "event" : sc.getText(propVal.params[1])
+            }, ${sc.getText(propVal.params[0])}) => ${sc.getText(
+              propVal.body
+            )}`,
+          ]);
+        }
+      } else if (propVal.type === "FunctionExpression") {
+        const paramsLen = propVal.params.length;
+        if (1 <= paramsLen <= 2) {
+          toReplace.push([
+            expr,
+            `function ${propVal.id ? sc.getText(propVal.id) : ""}(${
+              paramsLen === 1 ? "event" : sc.getText(propVal.params[1])
+            }, ${sc.getText(propVal.params[0])}) ${sc.getText(propVal.body)}`,
+          ]);
         }
       }
     };
+
+    const handleRightAssignmentSide_Object = (node, toReplace) => {
+      if (node.type === "ObjectExpression") {
+        handleObjectExpression(node, toReplace);
+      } else if (node.type === "Identifier") {
+        handleIdentifierOfObject(node, toReplace);
+      }
+    };
+
+    const handleIdentifierOfObject = (identifier, toReplace) => {
+      const variable = findVariableDeclaration(
+        identifier.name,
+        sc.getScope(identifier)
+      );
+
+      const nodesUsingVariable = variable?.references.map(
+        (ref) => ref.identifier.parent
+      );
+
+      nodesUsingVariable.forEach((n) => {
+        if (
+          n.type === "MemberExpression" &&
+          (n.property.name === "onChange" || n.property.value === "onChange") &&
+          n.parent.type === "AssignmentExpression"
+        ) {
+          rangeStartsToReplaceConst.push(variable?.defs[0].node.parent.range[0]);
+          toReplace.push([n, sc.getText(n.object)]);
+          handleRightAssignmentSide_Function(n.parent.right, toReplace);
+        } else if (
+          n.type === "AssignmentExpression" &&
+          n.left.name === identifier.name
+        ) {
+          handleRightAssignmentSide_Object(n.right, toReplace);
+        }
+      });
+
+      const variableValue = variable?.defs[0].node.init;
+      variableValue &&
+        handleRightAssignmentSide_Object(variableValue, toReplace);
+    };
+
+    const handleRightAssignmentSide_Function = (node, toReplace) => {
+      if (node.type.includes("FunctionExpression")) {
+        swapCallbackParam(node.params, toReplace);
+      } else if (node.type === "Identifier") {
+        handleIdentifierOfFunction(node, toReplace);
+      }
+    };
+
+    const handleIdentifierOfFunction = (identifier, toReplace) => {
+      const variable = findVariableDeclaration(
+        identifier.name,
+        sc.getScope(identifier)
+      );
+
+      const variableType = variable?.defs[0].type;
+      const variableNode = variable?.defs[0].node;
+
+      if (variableType === "Variable") {
+        const nodesUsingVariable = variable.references.map(
+          (ref) => ref.identifier.parent
+        );
+
+        nodesUsingVariable.forEach((n) => {
+          if (
+            n.type === "AssignmentExpression" &&
+            n.left.name === identifier.name
+          ) {
+            handleRightAssignmentSide_Function(n.right, toReplace);
+          }
+        });
+
+        variableNode.init &&
+          handleRightAssignmentSide_Function(variableNode.init, toReplace);
+      }
+
+      if (variableType === "FunctionName") {
+        swapCallbackParam(variableNode.params, toReplace);
+      }
+    };
+
+    const jsxOpeningsElementsToFix = getAllJSXElements(context)
+      .map((elem) => elem.openingElement)
+      .filter(
+        (openingElem) =>
+          openingElem.name.name === dataListImport.local.name &&
+          openingElem.attributes.some(
+            (attr) =>
+              attr.name.name === "selectableRow" &&
+              attr.value?.type === "JSXExpressionContainer"
+          )
+      );
+
+    let toReplace = [];
+
+    for (const elem of jsxOpeningsElementsToFix) {
+      const selectableRowAttr = elem.attributes.find(
+        (attr) =>
+          attr.name?.name === "selectableRow" &&
+          attr.value?.type === "JSXExpressionContainer"
+      );
+
+      if (!selectableRowAttr) {
+        continue;
+      }
+
+      const expr = selectableRowAttr.value.expression;
+
+      if (expr.type === "ObjectExpression") {
+        handleObjectExpression(expr, toReplace);
+      }
+
+      if (expr.type === "Identifier") {
+        handleIdentifierOfObject(expr, toReplace);
+      }
+
+      toReplace.push([selectableRowAttr.name, "onSelectableRowChange"]);
+    }
+
+    // Having the same fix more than once would lead to errors
+    let toReplaceUnique = [];
+
+    for (const [oldVal, newVal] of toReplace) {
+      if (
+        toReplaceUnique.every(
+          ([oldUnique, newUnique]) =>
+            oldUnique !== oldVal || newUnique !== newVal
+        )
+      ) {
+        toReplaceUnique.push([oldVal, newVal]);
+      }
+    }
+
+    const reportMessage = `DataList's selectableRow property has been replaced with onSelectableRowChange. The order of the params in the callback has also been updated so that the event param is first.`;
+
+    return {
+      // We use Program node to perform a one-time fix to prevent swapping callback parameters back and forth
+      Program(node) {
+        toReplaceUnique.length &&
+          context.report({
+            message: reportMessage,
+            node,
+            fix: function (fixer) {
+              return [
+                ...toReplaceUnique.map(([oldValue, newValue]) =>
+                  fixer.replaceText(oldValue, newValue)
+                ),
+                ...[...new Set(rangeStartsToReplaceConst)].map((rangeStart) =>
+                  fixer.replaceTextRange(
+                    [rangeStart, rangeStart + "const".length],
+                    "let"
+                  )
+                ),
+              ];
+            },
+          });
+      },
+      // Only to report where the node is located
+      JSXOpeningElement(node) {
+        if (jsxOpeningsElementsToFix.includes(node)) {
+          context.report({
+            message: reportMessage,
+            node,
+          });
+        }
+      },
+    };
   },
 };
-

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/dataList-onSelectableRowChange-updated-callback.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/dataList-onSelectableRowChange-updated-callback.js
@@ -1,0 +1,4 @@
+const { swapCallbackParamTester } = require("../../testHelpers");
+
+swapCallbackParamTester('dataList-onSelectableRowChange-updated-callback', 'DataList', 'onSelectableRowChange', 1)
+

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/datalist-remove-selectableRow.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/datalist-remove-selectableRow.js
@@ -1,35 +1,136 @@
-const ruleTester = require('../../ruletester');
-const rule = require('../../../lib/rules/v5/datalist-remove-selectableRow');
+const ruleTester = require("../../ruletester");
+const rule = require("../../../lib/rules/v5/datalist-remove-selectableRow");
 
 ruleTester.run("datalist-remove-selectableRow", rule, {
   valid: [
     {
-      code: `import { DataList } from '@patternfly/react-core'; <DataList onSelectableRowChange />`,
+      code: `
+      import { DataList } from "@patternfly/react-core";
+
+      const onChange = (event, id) => {};
+      function onChangeFunc(event, id) {};
+      
+      let selectableRowObject = function (event, id) {};
+      selectableRowObject = onChangeFunc;
+      selectableRowObject = onChange;
+      
+      let selectableRowObject2 = onChangeFunc;
+      selectableRowObject2 = selectableRowObject;
+      
+      <>
+        <DataList onSelectableRowChange={(event, id) => {}} />
+        <DataList onSelectableRowChange={onChangeFunc} />
+        <DataList onSelectableRowChange={onChange} />
+        
+        <DataList onSelectableRowChange={selectableRowObject} />
+        <DataList onSelectableRowChange={selectableRowObject2} />
+      </>;
+      `,
     },
     {
-      code: `import { DataList } from '@patternfly/react-core/dist/esm/components/DataList/index.js'; <DataList onSelectableRowChange />`,
+      code: `
+      import { DataList } from '@patternfly/react-core/dist/esm/components/DataList/index.js'; 
+
+      const onChange = (event, id) => {};
+      function onChangeFunc(event, id) {};
+      
+      let selectableRowObject = function (event, id) {};
+      selectableRowObject = onChangeFunc;
+      selectableRowObject = onChange;
+      
+      let selectableRowObject2 = onChangeFunc;
+      selectableRowObject2 = selectableRowObject;
+      
+      <>
+        <DataList onSelectableRowChange={(event, id) => {}} />
+        <DataList onSelectableRowChange={onChangeFunc} />
+        <DataList onSelectableRowChange={onChange} />
+        
+        <DataList onSelectableRowChange={selectableRowObject} />
+        <DataList onSelectableRowChange={selectableRowObject2} />
+      </>;
+      `,
     },
     {
       // No @patternfly/react-core import
-      code: `<DataList selectableRow />`,
-    }
+      code: `
+      const onChange = (id) => {};
+      function onChangeFunc(id, event) {};
+      
+      const selectableRowObject = { onChange: function (id, event) {} };
+      selectableRowObject.onChange = onChangeFunc;
+      selectableRowObject["onChange"] = onChange;
+      
+      let selectableRowObject2 = { onChange: onChangeFunc };
+      selectableRowObject2 = selectableRowObject;
+      
+      <>
+        <DataList selectableRow={{ onChange: (id, event) => {} }} />
+        <DataList selectableRow={{ onChange: onChangeFunc }} />
+        <DataList selectableRow={{ onChange }} />
+        
+        <DataList selectableRow={selectableRowObject} />
+        <DataList selectableRow={selectableRowObject2} />
+      </>;
+      `,
+    },
   ],
   invalid: [
     {
-      code:   `import { DataList } from '@patternfly/react-core/dist/esm/components/DataList/index.js'; <DataList selectableRow />`,
-      output: `import { DataList } from '@patternfly/react-core/dist/esm/components/DataList/index.js'; <DataList selectableRow />`,
-      errors: [{
-        message: `DataList's selectableRow property has been replaced with onSelectableRowChange. The order of the params in the callback has also been updated so that the event param is first.`,
-        type: "JSXOpeningElement",
-      }]
+      code: `
+      import { DataList } from "@patternfly/react-core";
+
+      const onChange = (id) => {};
+      function onChangeFunc(id, event) {};
+      
+      const selectableRowObject = { onChange: function (id, event) {} };
+      selectableRowObject.onChange = onChangeFunc;
+      selectableRowObject["onChange"] = onChange;
+      
+      let selectableRowObject2 = { onChange: onChangeFunc };
+      selectableRowObject2 = selectableRowObject;
+      
+      <>
+        <DataList selectableRow={{ onChange: (id, event) => {} }} />
+        <DataList selectableRow={{ onChange: onChangeFunc }} />
+        <DataList selectableRow={{ onChange }} />
+        
+        <DataList selectableRow={selectableRowObject} />
+        <DataList selectableRow={selectableRowObject2} />
+      </>;
+      `,
+      output: `
+      import { DataList } from "@patternfly/react-core";
+
+      const onChange = (event, id) => {};
+      function onChangeFunc(event, id) {};
+      
+      let selectableRowObject = function (event, id) {};
+      selectableRowObject = onChangeFunc;
+      selectableRowObject = onChange;
+      
+      let selectableRowObject2 = onChangeFunc;
+      selectableRowObject2 = selectableRowObject;
+      
+      <>
+        <DataList onSelectableRowChange={(event, id) => {}} />
+        <DataList onSelectableRowChange={onChangeFunc} />
+        <DataList onSelectableRowChange={onChange} />
+        
+        <DataList onSelectableRowChange={selectableRowObject} />
+        <DataList onSelectableRowChange={selectableRowObject2} />
+      </>;
+      `,
+      errors: [
+        {
+          message: `DataList's selectableRow property has been replaced with onSelectableRowChange. The order of the params in the callback has also been updated so that the event param is first.`,
+          type: "Program",
+        },
+        ...Array(5).fill({
+          message: `DataList's selectableRow property has been replaced with onSelectableRowChange. The order of the params in the callback has also been updated so that the event param is first.`,
+          type: "JSXOpeningElement",
+        }),
+      ],
     },
-    {
-      code:   `import { DataList } from '@patternfly/react-core'; <DataList selectableRow />`,
-      output: `import { DataList } from '@patternfly/react-core'; <DataList selectableRow />`,
-      errors: [{
-        message: `DataList's selectableRow property has been replaced with onSelectableRowChange. The order of the params in the callback has also been updated so that the event param is first.`,
-        type: "JSXOpeningElement",
-      }]
-    }
-  ]
+  ],
 });

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/datalist-remove-selectableRow.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/datalist-remove-selectableRow.js
@@ -77,59 +77,97 @@ ruleTester.run("datalist-remove-selectableRow", rule, {
   ],
   invalid: [
     {
-      code: `
-      import { DataList } from "@patternfly/react-core";
-
+      code: `import { DataList } from "@patternfly/react-core";
+      <DataList selectableRow={{ onChange: (id, event) => {} }} />;`,
+      output: `import { DataList } from "@patternfly/react-core";
+      <DataList onSelectableRowChange={(id, event) => {}} />;`,
+      errors: [
+        {
+          message: `DataList's selectableRow property has been replaced with onSelectableRowChange. The order of the params in the callback has also been updated so that the event param is first.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    {
+      code: `import { DataList } from "@patternfly/react-core";
+      function onChangeFunc(id, event) {};
+      <DataList selectableRow={{ onChange: onChangeFunc }} />;`,
+      output: `import { DataList } from "@patternfly/react-core";
+      function onChangeFunc(id, event) {};
+      <DataList onSelectableRowChange={onChangeFunc} />;`,
+      errors: [
+        {
+          message: `DataList's selectableRow property has been replaced with onSelectableRowChange. The order of the params in the callback has also been updated so that the event param is first.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    {
+      code: `import { DataList } from "@patternfly/react-core";
+      const onChange = (id) => {};
+      <DataList selectableRow={{ onChange }} />;`,
+      output: `import { DataList } from "@patternfly/react-core";
+      const onChange = (id) => {};
+      <DataList onSelectableRowChange={onChange} />;`,
+      errors: [
+        {
+          message: `DataList's selectableRow property has been replaced with onSelectableRowChange. The order of the params in the callback has also been updated so that the event param is first.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    {
+      code: `import { DataList } from "@patternfly/react-core";
       const onChange = (id) => {};
       function onChangeFunc(id, event) {};
       
       const selectableRowObject = { onChange: function (id, event) {} };
       selectableRowObject.onChange = onChangeFunc;
       selectableRowObject["onChange"] = onChange;
-      
-      let selectableRowObject2 = { onChange: onChangeFunc };
-      selectableRowObject2 = selectableRowObject;
-      
-      <>
-        <DataList selectableRow={{ onChange: (id, event) => {} }} />
-        <DataList selectableRow={{ onChange: onChangeFunc }} />
-        <DataList selectableRow={{ onChange }} />
-        
-        <DataList selectableRow={selectableRowObject} />
-        <DataList selectableRow={selectableRowObject2} />
-      </>;
-      `,
-      output: `
-      import { DataList } from "@patternfly/react-core";
 
-      const onChange = (event, id) => {};
-      function onChangeFunc(event, id) {};
+      <DataList selectableRow={selectableRowObject} />;`,
+      output: `import { DataList } from "@patternfly/react-core";
+      const onChange = (id) => {};
+      function onChangeFunc(id, event) {};
       
-      let selectableRowObject = function (event, id) {};
+      let selectableRowObject = function (id, event) {};
       selectableRowObject = onChangeFunc;
       selectableRowObject = onChange;
-      
-      let selectableRowObject2 = onChangeFunc;
-      selectableRowObject2 = selectableRowObject;
-      
-      <>
-        <DataList onSelectableRowChange={(event, id) => {}} />
-        <DataList onSelectableRowChange={onChangeFunc} />
-        <DataList onSelectableRowChange={onChange} />
-        
-        <DataList onSelectableRowChange={selectableRowObject} />
-        <DataList onSelectableRowChange={selectableRowObject2} />
-      </>;
-      `,
+
+      <DataList onSelectableRowChange={selectableRowObject} />;`,
       errors: [
         {
           message: `DataList's selectableRow property has been replaced with onSelectableRowChange. The order of the params in the callback has also been updated so that the event param is first.`,
-          type: "Program",
+          type: "JSXOpeningElement",
         },
-        ...Array(5).fill({
+      ],
+    },
+    {
+      code: `
+      import { DataList } from "@patternfly/react-core";
+
+      function onChangeFunc(id, event) {};
+      
+      const selectableRowObject = { onChange: function (id, event) {} };
+      let selectableRowObject2 = { onChange: onChangeFunc };
+      selectableRowObject2 = selectableRowObject;
+      
+      <DataList selectableRow={selectableRowObject2} />;`,
+      output: `
+      import { DataList } from "@patternfly/react-core";
+
+      function onChangeFunc(id, event) {};
+      
+      const selectableRowObject = function (id, event) {};
+      let selectableRowObject2 = onChangeFunc;
+      selectableRowObject2 = selectableRowObject;
+      
+      <DataList onSelectableRowChange={selectableRowObject2} />;`,
+      errors: [
+        {
           message: `DataList's selectableRow property has been replaced with onSelectableRowChange. The order of the params in the callback has also been updated so that the event param is first.`,
           type: "JSXOpeningElement",
-        }),
+        },
       ],
     },
   ],

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -672,7 +672,7 @@ We've removed the selectableRow property and replaced it with onSelectableRowCha
 was a callback, which can now be directly passed to the onSelectableRowChange prop. However, it's worth noting that the order of the params 
 in the callback has been updated so that the event param is first.
 
-#### Example of manual change needed
+#### Examples
 
 In:
 
@@ -690,14 +690,14 @@ const selectableRowObject = { onChange: onChange};
 Out:
 
 ```jsx
-<DataList onSelectableRowChange={ (event, id) => {} } />
+<DataList onSelectableRowChange={(event, id) => {}} />
 
-const onSelectableRowChange = (event, id) => {};
-<DataList onSelectableRowChange={onSelectableRowChange} />
+const selectableRowObject = (event, id) => {};
+<DataList onSelectableRowChange={selectableRowObject} />
 
 const onChange = (event, id) => {};
-<DataList onSelectableRowChange={onChange} />
-
+const selectableRowObject2 = onChange;
+<DataList onSelectableRowChange={selectableRowObject2} />
 ```
 
 ### dataList-updated-callback [(#8723)](https://github.com/patternfly/patternfly-react/pull/8723)

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -646,6 +646,38 @@ Out:
 import { ContextSelector, ContextSelectorItem } from '@patternfly/react-core/deprecated';
 ```
 
+### dataList-onSelectableRowChange-updated-callback [(#8827)](https://github.com/patternfly/patternfly-react/pull/8827)
+
+We've removed the `selectableRow` property for DataList and replaced it with `onSelectableRowChange`. The value of the selectableRow's onChange field
+was a callback, which can now be directly passed to the onSelectableRowChange prop. We have a special rule `datalist-remove-selectableRow` for that change.
+
+However, it's worth noting that the order of the params in the `onSelectableRowChange` callback has been updated so that the `event` parameter is the first parameter. Handlers may require an update.
+
+#### Examples
+
+In:
+
+```jsx
+<DataList onSelectableRowChange={(id) => handler(id)} />
+<DataList onSelectableRowChange={(id, event) => handler(id, event)} />
+const handler1 = (id, event) => {};
+<DataList onSelectableRowChange={handler1} />
+function handler2(id, event) {};
+<DataList onSelectableRowChange={handler2} />
+```
+
+Out:
+
+```jsx
+<DataList onSelectableRowChange={(_event, id) => handler(id)} />
+<DataList onSelectableRowChange={(event, id) => handler(id, event)} />
+const handler1 = (_event, id) => {};
+<DataList onSelectableRowChange={handler1} />
+function handler2(_event, id) {};
+<DataList onSelectableRowChange={handler2} />
+```
+
+
 ### datalist-remove-props [(#8388)](https://github.com/patternfly/patternfly-react/pull/8388)
 
 We've removed the deprecated `onDragFinish`, `onDragStart`, `onDragMove`, `onDragCancel`, and `itemOrder` props from DataList.
@@ -668,9 +700,12 @@ Out:
 
 ### datalist-remove-selectableRow [(#8827)](https://github.com/patternfly/patternfly-react/pull/8827)
 
-We've removed the selectableRow property and replaced it with onSelectableRowChange. The value of the selectableRow's onChange field
-was a callback, which can now be directly passed to the onSelectableRowChange prop. However, it's worth noting that the order of the params 
-in the callback has been updated so that the event param is first.
+We've removed the `selectableRow` property for DataList and replaced it with `onSelectableRowChange`. The value of the selectableRow's onChange field
+was a callback, which can now be directly passed to the onSelectableRowChange prop. 
+
+However, it's worth noting that the order of the params in the callback has been updated so that the event param is first. This rule on its own will not update the callback, but we also introduced the `dataList-onSelectableRowChange-updated-callback` rule, which updates the callback accordingly, once this `datalist-remove-selectableRow` rule has finished.
+
+This rule is a setup rule, meaning it will run before others, so the `dataList-onSelectableRowChange-updated-callback` rule can update the callback correctly.
 
 #### Examples
 
@@ -683,19 +718,19 @@ const selectableRowObject = { onChange: (id, event) => {}};
 <DataList selectableRow={selectableRowObject} />
 
 const onChange = (id, event) => {};
-const selectableRowObject = { onChange: onChange};
-<DataList selectableRow={selectableRowObject} />
+const selectableRowObject2 = { onChange: onChange};
+<DataList selectableRow={selectableRowObject2} />
 ```
 
 Out:
 
 ```jsx
-<DataList onSelectableRowChange={(event, id) => {}} />
+<DataList onSelectableRowChange={(id, event) => {}} />
 
-const selectableRowObject = (event, id) => {};
+const selectableRowObject = (id, event) => {};
 <DataList onSelectableRowChange={selectableRowObject} />
 
-const onChange = (event, id) => {};
+const onChange = (id, event) => {};
 const selectableRowObject2 = onChange;
 <DataList onSelectableRowChange={selectableRowObject2} />
 ```
@@ -770,6 +805,10 @@ The helperText property of `DatePicker` now expects the <HelperText> component, 
 
 This rule will raise a warning, but will not make any code changes
 
+### deprecatedSelect-warn-markupUpdated [(#9172)](https://github.com/patternfly/patternfly-react/pull/9172)
+
+Our deprecated implementation of Select has had its markup changed. Selectors may require updating. This rule will raise a warning, but will not make any changes.
+
 ### divider-remove-isVertical [(#8199)](https://github.com/patternfly/patternfly-react/pull/8199)
 
 We've replaced the `isVertical` flag with the `orientation` property that can define verticality on different breakpoints.
@@ -785,10 +824,6 @@ Out:
 ```jsx
 <Divider orientation={{ default: "vertical" }} />
 ```
-
-### deprecatedSelect-warn-markupUpdated [(#9172)](https://github.com/patternfly/patternfly-react/pull/9172)
-
-Our deprecated implementation of Select has had its markup changed. Selectors may require updating. This rule will raise a warning, but will not make any changes.
 
 ### drawerPanelContent-warn-updated-callback [(#8736)](https://github.com/patternfly/patternfly-react/pull/8736)
 
@@ -1792,20 +1827,6 @@ The placement Nav flyouts in the DOM has been changed, if you have Nav elements 
 ### nextComponents-update-path [(#8821)](https://github.com/patternfly/patternfly-react/pull/8821) [(#8825)](https://github.com/patternfly/patternfly-react/pull/8825) [(#8835)](https://github.com/patternfly/patternfly-react/pull/8835)
 
 We've promoted the "Next" implementations of our Dropdown, Select, and Wizard components and they are now our default implementation. This rule will update import and/or export paths.
-
-### Examples
-
-In:
-
-```tsx
-import { Dropdown } from '@patternfly/react-core/next';
-```
-
-Out:
-
-```tsx
-import { Dropdown /* data-codemods */ } from '@patternfly/react-core/next';
-```
 
 ### no-unused-imports-v5
 

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -1828,6 +1828,20 @@ The placement Nav flyouts in the DOM has been changed, if you have Nav elements 
 
 We've promoted the "Next" implementations of our Dropdown, Select, and Wizard components and they are now our default implementation. This rule will update import and/or export paths.
 
+### Examples
+
+In:
+
+```tsx
+import { Dropdown } from '@patternfly/react-core/next';
+```
+
+Out:
+
+```tsx
+import { Dropdown /* data-codemods */ } from '@patternfly/react-core/next';
+```
+
 ### no-unused-imports-v5
 
 This rule, when run with `--fix` option, removes all unused imports from `patternfly/react` packages. It is a cleanup rule which will run after all the rules.

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -177,7 +177,7 @@ const alertVariantOption = AlertVariant.default;
   </ContextSelector>
   <DataList onDragStart itemOrder={["1", "2", "3"]} />
   <DataList onSelectDataListItem={(id, text) => handler(id, text)} />
-  <DataList selectableRow={{ onChange = () => {} }} />
+  <DataList selectableRow={{onChange: (id, event) => {}}} />
   <DataListCheck onChange={(id) => handler} />
   <DatePicker />
   <DrawerPanelContent onResize={(id, width) => {}} />

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -177,6 +177,7 @@ const alertVariantOption = AlertVariant.default;
   </ContextSelector>
   <DataList onDragStart itemOrder={["1", "2", "3"]} />
   <DataList onSelectDataListItem={(id, text) => handler(id, text)} />
+  <DataList onSelectableRowChange={(id, event) => handler(id, event)} />
   <DataList selectableRow={{onChange: (id, event) => {}}} />
   <DataListCheck onChange={(id) => handler} />
   <DatePicker />


### PR DESCRIPTION
Closes #368

One thing I don't like about this fixer is that when having an object inside the `selectableRow` prop like this:

```
const selectableRowObject = { onChange: (id, event) => {}};
<DataList selectableRow={selectableRowObject} />
```

It does not change the `selectableRowObject` variable name, but changes its type from an object to a function like this:
```
const selectableRowObject = (event, id) => {};
<DataList onSelectableRowChange={selectableRowObject} />
```

I mean, it could be renamed but at the same time we should not rename consumers variables. After writing the fixer, I get why this is one of the codemods which is better to be repaired manually.