### PR TITLE
fix(Table): updated isHoverable to isClickable

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/table-rename-isHoverable.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/table-rename-isHoverable.js
@@ -1,0 +1,56 @@
+const { getPackageImports, renamePropsOnNode } = require("../../helpers");
+
+// https://github.com/patternfly/patternfly-react/pull/9083
+module.exports = {
+  meta: { fixable: "code" },
+  create: function (context) {
+    const tableImports = getPackageImports(
+      context,
+      "@patternfly/react-table"
+    ).filter((specifier) => ["Table", "Tr"].includes(specifier.imported.name));
+    const deprecatedTableImports = getPackageImports(
+      context,
+      "@patternfly/react-table/deprecated"
+    ).filter((specifier) => specifier.imported.name === "Table");
+
+    const allTableImports = [...tableImports, ...deprecatedTableImports];
+
+    return !allTableImports.length
+      ? {}
+      : {
+          JSXOpeningElement(node) {
+            if (
+              allTableImports
+                .map((imp) => imp.local.name)
+                .includes(node.name.name)
+            ) {
+              const getAttribute = (attributeToGet) =>
+                node.attributes.find(
+                  (attr) => attr.name?.name === attributeToGet
+                );
+
+              const rowsProp = getAttribute("rows");
+              const isHoverableProp = getAttribute("isHoverable");
+
+              if (rowsProp) {
+                context.report({
+                  node,
+                  message: `The IRow interface for the "rows" prop on ${node.name?.name} has had its "isHoverable" prop renamed to "isClickable". If you are using "isHoverable" it must be updated manually.`,
+                });
+              }
+
+              if (isHoverableProp) {
+                renamePropsOnNode(context, tableImports, node, {
+                  Tr: {
+                    isHoverable: {
+                      newName: "isClickable",
+                      message: `The "isHoverable" prop on ${node.name?.name} has been renamed to "isClickable".`,
+                    },
+                  },
+                });
+              }
+            }
+          },
+        };
+  },
+};

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/table-rename-isHoverable.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/table-rename-isHoverable.js
@@ -1,0 +1,64 @@
+const ruleTester = require("../../ruletester");
+const rule = require("../../../lib/rules/v5/table-rename-isHoverable");
+
+ruleTester.run("table-rename-isHoverable", rule, {
+  valid: [
+    {
+      code: `import { Tr } from '@patternfly/react-table'; <Tr isClickable />`,
+    },
+    // TableComposable after being renamed to Table
+    {
+      code: `import { Table } from '@patternfly/react-table'; <Table />`,
+    },
+    // No @patternfly import
+    {
+      code: `<Tr isHoverable />`,
+    },
+    // No @patternfly import
+    {
+      code: `<Table rows={rows} />`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import { Tr } from '@patternfly/react-table'; <Tr isHoverable />`,
+      output: `import { Tr } from '@patternfly/react-table'; <Tr isClickable />`,
+      errors: [
+        {
+          message: `The "isHoverable" prop on Tr has been renamed to "isClickable".`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    {
+      code: `import { Tr } from '@patternfly/react-table/dist/esm/components/Table/index.js'; <Tr isHoverable />`,
+      output: `import { Tr } from '@patternfly/react-table/dist/esm/components/Table/index.js'; <Tr isClickable />`,
+      errors: [
+        {
+          message: `The "isHoverable" prop on Tr has been renamed to "isClickable".`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    {
+      code: `import { Table } from '@patternfly/react-table'; <Table rows={rows} />`,
+      output: `import { Table } from '@patternfly/react-table'; <Table rows={rows} />`,
+      errors: [
+        {
+          message: `The IRow interface for the "rows" prop on Table has had its "isHoverable" prop renamed to "isClickable". If you are using "isHoverable" it must be updated manually.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    {
+      code: `import { Table } from '@patternfly/react-table/deprecated'; <Table rows={rows} />`,
+      output: `import { Table } from '@patternfly/react-table/deprecated'; <Table rows={rows} />`,
+      errors: [
+        {
+          message: `The IRow interface for the "rows" prop on Table has had its "isHoverable" prop renamed to "isClickable". If you are using "isHoverable" it must be updated manually.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -2099,6 +2099,26 @@ Out:
 <Spinner  />
 ```
 
+### table-rename-isHoverable [((#9083))](https://github.com/patternfly/patternfly-react/pull/9083)
+
+We've renamed the `isHoverable` prop for Table components to `isClickable`. This rule provides a fix for the `Tr` component when using our new default, composable implementation of Table.
+
+If using our now deprecated implementation of Table with the `rows` prop passed in, only an error message will be thrown and any usage of `isHoverable` will need to be updated manually.
+
+#### Examples
+
+In:
+
+```jsx
+<Tr isHoverable />
+```
+
+Out:
+
+```jsx
+<Tr isClickable />
+```
+
 ### table-update-deprecatedPath [(#8892)](https://github.com/patternfly/patternfly-react/pull/8892)
 
 We've deprecated the current implementation of Table. In order to continue using this deprecated implementation, the import path must be updated to our deprecated package and specifiers must be aliased. However, we suggest updating to our composable Table implementation.

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -98,17 +98,16 @@ import {
   WizardBody as WizardBodyNext,
   WizardFooter,
 } from "@patternfly/react-core/next";
-
-import { Td } from "@patternfly/react-table";
-
-const tdSelectTypeObj = { disable: true };
 import {
   Table,
   TableBody,
   TableHeader,
   TableProps,
+  Td,
+  Tr,
 } from "@patternfly/react-table";
 
+const tdSelectTypeObj = { disable: true };
 //following type of import was causing errors for rules that checked specifiers before import package
 import foo from "Bar";
 
@@ -241,6 +240,7 @@ const alertVariantOption = AlertVariant.default;
   <Slider onChange={(foo) => handler(foo)} />
   <Spinner isSVG />
   <Table />
+  <Table rows={[]} />
   <TableBody />
   <TableHeader />
   <Td select={tdSelectTypeObj} actions={{ disable: false }} />
@@ -248,6 +248,7 @@ const alertVariantOption = AlertVariant.default;
   <Toggle isPrimary onToggle={} />
   <ToggleGroupItem onChange={(foo, event) => handler(foo, event)} />
   <Tooltip reference />
+  <Tr isHoverable />
   <TreeView hasCheck />
   <Wizard />
   <Wizard mainAriaLabel />


### PR DESCRIPTION
Closes #451 

Due to the less-than-simple ways that the deprecated Table's `rows` prop could be passed in, I only provided an error message for now. 

- We could split the Tr and Table (deprecated) updates into separate codemods so that Table is a warning instead of an error. *Technically* it might not break anything except visually (although tests might fail since isClickable applies a tabIndex for keyboard focusability).
- We could provide some fixes for a couple of the ways that `rows` could be passed in: an array or a reference to an arrow function like in our [Legacy clickable rows example](https://patternfly-react-v5.surge.sh/components/table/react-deprecated#clickable-rows-selectable-rows-and-header-cell-tooltipspopovers)