### PR TITLE
chore(Card): deprecated props

### DIFF
--- a/packages/eslint-plugin-pf-codemods/index.js
+++ b/packages/eslint-plugin-pf-codemods/index.js
@@ -8,6 +8,7 @@ const betaRuleNames = [
 const warningRules = [
   "aboutModalBoxHero-remove-subcomponent",
   "applicationLauncher-warn-input",
+  "card-deprecate-props",
   "card-warn-component",
   "charts-warn-tooltip",
   "conditional-aria",
@@ -28,7 +29,11 @@ const warningRules = [
 ];
 
 // rules that will run before other rules (move to deprecated?)
-const setupRules = ["pageHeader-deprecated", "select-deprecated", "table-update-deprecatedPath"];
+const setupRules = [
+  "pageHeader-deprecated",
+  "select-deprecated",
+  "table-update-deprecatedPath",
+];
 
 // rules that will run after other rules (cleanup imports?)
 const cleanupRules = ["no-unused-imports-v5"];

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/card-deprecate-props.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/card-deprecate-props.js
@@ -1,0 +1,69 @@
+const { getPackageImports } = require("../../helpers");
+
+// https://github.com/patternfly/patternfly-react/pull/9092
+module.exports = {
+  meta: { fixable: "code" },
+  create: function (context) {
+    const cardImport = getPackageImports(
+      context,
+      "@patternfly/react-core"
+    ).find((specifier) => specifier.imported.name === "Card");
+
+    return !cardImport
+      ? {}
+      : {
+          JSXOpeningElement(node) {
+            if (node.name?.name !== cardImport.local?.name) {
+              return;
+            }
+
+            const selectableInputProps = [
+              "hasSelectableInput",
+              "selectableInputAriaLabel",
+              "onSelectableInputChange",
+            ];
+            const raisedProps = ["isSelectableRaised", "isDisabledRaised"];
+
+            const deprecatedAttributes = node.attributes.filter((attr) =>
+              [...selectableInputProps, ...raisedProps].includes(
+                attr.name?.name
+              )
+            );
+
+            deprecatedAttributes.forEach((attr) => {
+              const { name } = attr.name;
+
+              context.report({
+                node,
+                message: `The "${name}" prop on ${node.name.name} has been deprecated. We recommend using our new implementation of clickable and selectable Cards instead.`,
+                fix(fixer) {
+                  if (!raisedProps.includes(name)) {
+                    return;
+                  }
+                  const fixes = [
+                    fixer.replaceText(attr, name.replace("Raised", "")),
+                  ];
+
+                  // tabIndex now needs to be manually passed in when using isSelectable and hasSelectableInput
+                  if (
+                    name.startsWith("isSelectable") &&
+                    deprecatedAttributes.find(
+                      (attr) => attr.name.name === "hasSelectableInput"
+                    )
+                  ) {
+                    fixes.push(
+                      fixer.insertTextAfter(
+                        node.attributes[node.attributes.length - 1],
+                        " tabIndex={0}"
+                      )
+                    );
+                  }
+
+                  return fixes;
+                },
+              });
+            });
+          },
+        };
+  },
+};

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/card-deprecate-props.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/card-deprecate-props.js
@@ -1,0 +1,87 @@
+const ruleTester = require("../../ruletester");
+const rule = require("../../../lib/rules/v5/card-deprecate-props");
+
+ruleTester.run("card-deprecate-props", rule, {
+  valid: [
+    {
+      code: `import { Card } from '@patternfly/react-core'; <Card isSelectable isDisabled />`,
+    },
+    // no @patternfly/react-core import
+    {
+      code: `<Card isSelectableRaised isDisabledRaised hasSelectableInput selectableInputAriaLabel onSelectableInputChange />`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import { Card } from '@patternfly/react-core'; <Card isSelectableRaised />`,
+      output: `import { Card } from '@patternfly/react-core'; <Card isSelectable />`,
+      errors: [
+        {
+          message: `The "isSelectableRaised" prop on Card has been deprecated. We recommend using our new implementation of clickable and selectable Cards instead.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    {
+      code: `import { Card } from '@patternfly/react-core'; <Card isDisabledRaised />`,
+      output: `import { Card } from '@patternfly/react-core'; <Card isDisabled />`,
+      errors: [
+        {
+          message: `The "isDisabledRaised" prop on Card has been deprecated. We recommend using our new implementation of clickable and selectable Cards instead.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    ...[
+      "hasSelectableInput",
+      "selectableInputAriaLabel",
+      "onSelectableInputChange",
+    ].map((inputProp) => ({
+      code: `import { Card } from '@patternfly/react-core'; <Card ${inputProp} />`,
+      output: `import { Card } from '@patternfly/react-core'; <Card ${inputProp} />`,
+      errors: [
+        {
+          message: `The "${inputProp}" prop on Card has been deprecated. We recommend using our new implementation of clickable and selectable Cards instead.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    })),
+    // Import from dist
+    {
+      code: `import { Card } from '@patternfly/react-core/dist/esm/components/Card/index.js'; <Card isSelectableRaised />`,
+      output: `import { Card } from '@patternfly/react-core/dist/esm/components/Card/index.js'; <Card isSelectable />`,
+      errors: [
+        {
+          message: `The "isSelectableRaised" prop on Card has been deprecated. We recommend using our new implementation of clickable and selectable Cards instead.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    // Aliased import
+    {
+      code: `import { Card as PFCard } from '@patternfly/react-core/dist/esm/components/Card/index.js'; <PFCard isSelectableRaised />`,
+      output: `import { Card as PFCard } from '@patternfly/react-core/dist/esm/components/Card/index.js'; <PFCard isSelectable />`,
+      errors: [
+        {
+          message: `The "isSelectableRaised" prop on PFCard has been deprecated. We recommend using our new implementation of clickable and selectable Cards instead.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    // Add tabIndex when applicable
+    {
+      code: `import { Card } from '@patternfly/react-core'; <Card isSelectableRaised hasSelectableInput />`,
+      output: `import { Card } from '@patternfly/react-core'; <Card isSelectable hasSelectableInput tabIndex={0} />`,
+      errors: [
+        {
+          message: `The "isSelectableRaised" prop on Card has been deprecated. We recommend using our new implementation of clickable and selectable Cards instead.`,
+          type: "JSXOpeningElement",
+        },
+        {
+          message: `The "hasSelectableInput" prop on Card has been deprecated. We recommend using our new implementation of clickable and selectable Cards instead.`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/pf-codemods/README.md
+++ b/packages/pf-codemods/README.md
@@ -294,6 +294,35 @@ function handler2(_event, newDate) {};
 <CalendarMonth onChange={changeHandler2} onMonthChange={handler2}>
 ```
 
+### card-deprecate-props [(#9092)](https://github.com/patternfly/patternfly-react/pull/9092)
+
+The following props have been deprecated on Card:
+
+- isSelectableRaised
+- isDisabledRaised
+- hasSelectableInput
+- selectableInputAriaLabel
+- onSelectableInputChange
+
+We recommend using our new implementation of clickable and selectable cards instead. This rule will raise a warning, but can provide fixes when using the `isSelectableRaised` or `isDisabledRaised` props.
+
+#### Examples
+
+In:
+
+```jsx
+<Card isSelectableRaised isDisabledRaised />
+<Card isSelectableRaised hasSelectableInput />
+```
+
+Out:
+
+```jsx
+<Card isSelectable isDisabled />
+<Card isSelectable hasSelectableInput tabIndex={0} />
+```
+
+
 ### card-remove-isHoverable [(#8196)](https://github.com/patternfly/patternfly-react/pull/8196)
 
 We've removed the deprecated `isHoverable` prop from Card.
@@ -2366,30 +2395,6 @@ Out:
 <Spinner  />
 ```
 
-### table-rename-isHoverable [((#9083))](https://github.com/patternfly/patternfly-react/pull/9083)
-
-We've renamed the `isHoverable` prop for Table components to `isClickable`. This rule provides a fix for the `Tr` component when using our new default, composable implementation of Table.
-
-If using our now deprecated implementation of Table with the `rows` prop passed in, only an error message will be thrown and any usage of `isHoverable` will need to be updated manually.
-
-#### Examples
-
-In:
-
-```jsx
-<Tr isHoverable />
-```
-
-Out:
-
-```jsx
-<Tr isClickable />
-```
-
-### table-update-deprecatedPath [(#8892)](https://github.com/patternfly/patternfly-react/pull/8892)
-
-We've deprecated the current implementation of Table. In order to continue using this deprecated implementation, the import path must be updated to our deprecated package and specifiers must be aliased. However, we suggest updating to our composable Table implementation.
-  
 ### switch-onChange-swap-params [(#9037)](https://github.com/patternfly/patternfly-react/pull/9037)
 
 We've updated the `onChange` prop for Switch so that the `event` parameter is the first parameter. Handlers may require an update.
@@ -2418,6 +2423,26 @@ function handler2(_event, id) {};
 <Switch onChange={handler2} />
 ```
 
+
+### table-rename-isHoverable [((#9083))](https://github.com/patternfly/patternfly-react/pull/9083)
+
+We've renamed the `isHoverable` prop for Table components to `isClickable`. This rule provides a fix for the `Tr` component when using our new default, composable implementation of Table.
+
+If using our now deprecated implementation of Table with the `rows` prop passed in, only an error message will be thrown and any usage of `isHoverable` will need to be updated manually.
+
+#### Examples
+
+In:
+
+```jsx
+<Tr isHoverable />
+```
+
+Out:
+
+```jsx
+<Tr isClickable />
+```
 
 ### table-rename-TableComposable [(#8892)](https://github.com/patternfly/patternfly-react/pull/8892)
 
@@ -2465,6 +2490,10 @@ import {
 } from '@patternfly/react-table/deprecated';
 ```
 
+### table-update-deprecatedPath [(#8892)](https://github.com/patternfly/patternfly-react/pull/8892)
+
+We've deprecated the current implementation of Table. In order to continue using this deprecated implementation, the import path must be updated to our deprecated package and specifiers must be aliased. However, we suggest updating to our composable Table implementation.
+  
 ### table-warn-actionsColumn [(#8629)](https://github.com/patternfly/patternfly-react/pull/8629)
 
 Table and TableComposable's `ActionsColumn` has been updated to use our new implementation of Dropdown. The toggle passed to the actions column should now be a `MenuToggle` instead of the deprecated `DropdownToggle`. The `dropdownPosition`, `dropdownDirection` and `menuAppendTo` properties are removed and `Popper` properties can be passed in using `popperProps` instead (via `direction`, `position`, `appendTo`, etc.).

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -104,7 +104,7 @@ import {
   ToggleTemplateProps,
   Tooltip,
   TreeView,
-  Wizard
+  Wizard,
 } from "@patternfly/react-core";
 import {
   SelectOption,
@@ -153,6 +153,12 @@ const alertVariantOption = AlertVariant.default;
     onChange={(date) => handleChange(date)}
     onMonthChange={(newDate, evt) => handleMonthChange(newDate, evt)}
   />
+  <Card
+    isSelectableRaised
+    isDisabledRaised
+    hasSelectableInput
+    selectableInputAriaLabel
+  />
   <Card onSelectableInputChange={(label, _ev) => handler(label)} />
   <CardHeader>
     <CardHeaderMain>Header content</CardHeaderMain>
@@ -187,7 +193,10 @@ const alertVariantOption = AlertVariant.default;
     onChosenOptionsSearchInputChanged={(foo, event) => handler(foo, event)}
   />
   <DualListSelector onListChange={(foo) => handler(foo)} />
-  <EditableSelectInputCell onSelect={(foo, event) => onSelectHandler(foo, event)} clearSelection={foo => clearSelectionHandler(foo, event)} />
+  <EditableSelectInputCell
+    onSelect={(foo, event) => onSelectHandler(foo, event)}
+    clearSelection={(foo) => clearSelectionHandler(foo, event)}
+  />
   <EmptyState variant={EmptyStateVariant.large}>
     <EmptyStateIcon icon={CubesIcon} />
     <Title headingLevel='h5' size='4xl'>
@@ -206,7 +215,7 @@ const alertVariantOption = AlertVariant.default;
     onReadFinished={(fileHandle) => readFinishedHandler(fileHandle)}
     onReadStarted={(fileHandle) => readStartedHandler(fileHandle)}
   />
-  <FileUpload onTextChange={bar => textHandler(bar)} />
+  <FileUpload onTextChange={(bar) => textHandler(bar)} />
   <FileUploadField onTextChange={(bar) => textHandler(bar)} />
   <FormSelect onChange={(foo, event) => handler(foo, event)} />
   <FrogIcon size='sm' color='green' noVerticalAlign />
@@ -234,8 +243,8 @@ const alertVariantOption = AlertVariant.default;
   <ModalContent titleIconVariant='default'></ModalContent>
   <MultipleFileUpload onFileDrop={(foo) => handler(foo)} />
   <Nav flyout={"menu"} />
-  <Nav variant='horizontal-subnav' />
   <Nav onSelect={(foo) => handler(foo)} onToggle={(foo) => handler(foo)} />
+  <Nav variant='horizontal-subnav' />
   <NotificationBadge isRead />
   <NotificationBadge isRead={false} />
   <NotificationBadge isRead={isRead} />
@@ -268,11 +277,11 @@ const alertVariantOption = AlertVariant.default;
     toggleTemplate={({ first, second }: ToggleTemplateProps) => <></>}
   />
   <PFTable>Body</PFTable>
-  <Popover reference alertSeverityVariant='default' />
   <Popover
     shouldClose={(foo, event) => handler(foo, event)}
     shouldOpen={(fn) => openHandler(fn)}
   />
+  <Popover reference alertSeverityVariant='default' />
   <Popper popperMatchesTriggerWidth={false} />
   <ProgressStep />
   <Radio onChange={(foo, event) => handler(foo, event)} />
@@ -287,7 +296,7 @@ const alertVariantOption = AlertVariant.default;
   <TableBody />
   <TableComposable />
   <TableHeader />
-  <Tabs onToggle={foo => handler(foo)} />
+  <Tabs onToggle={(foo) => handler(foo)} />
   <Td select={tdSelectTypeObj} actions={{ disable: false }} />
   <TextArea onChange={(foo, event) => handler(foo, event)} />
   <TextInput onChange={(foo, event) => handler(foo, event)} />


### PR DESCRIPTION
Closes #476 

Adding the tabIndex to a Card may work better as a separate rule, but figured I'd add it into the fix that updates isSelectableRaised to isSelectable.