### PR TITLE
fix(Popover): fix issue with identifier handlers, remove fixers

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/popover-remove-props.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/popover-remove-props.js
@@ -50,20 +50,30 @@ module.exports = {
             const attr = node.openingElement.attributes.find(attribute => attribute.name?.name === name)
             if(attr) {
               const funct = attr.value.expression;
-              if(funct.params.length === 1) {
-                const firstParam = funct.params[0];
+              let params = [];
+              if ( funct.type === 'Identifier') {
+                const propProperties = {
+                  type: attr.value?.expression?.type,
+                  name: attr.value?.expression?.name,
+                };
+                const currentScope = context.getScope();
+                const matchingVariable = currentScope.variables.find(
+                  (variable) => variable.name === propProperties.name
+                );
+                const matchingDefinition = matchingVariable?.defs.find(
+                  (def) => def.name?.name === propProperties.name
+                );
+                params = 
+                  matchingDefinition?.type === "FunctionName"
+                    ? matchingDefinition?.node?.params
+                    : matchingDefinition?.node?.init?.params;
+              } else {
+                params = funct?.params;
+              }
+              if(params?.length) {
                 context.report({
                   node,
-                  message: "Popover " + attr.name.name + " function's parameter has been removed.",
-                  fix(fixer) {
-                    const fixes = [];
-                    if (funct.range[0] === firstParam.range[0]) {
-                      fixes.push(fixer.replaceText(firstParam, '()'));
-                    } else  {
-                      fixes.push(fixer.remove(firstParam));
-                    }
-                    return fixes;
-                  }
+                  message: "Popover " + attr.name.name + " function's parameter has been removed. Please update your code accordingly.",
                 });
               }
             }

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/popover-remove-props.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/popover-remove-props.js
@@ -10,6 +10,10 @@ ruleTester.run("popover-remove-props", rule, {
       code: `import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/index.js'; <Popover />`,
     },
     {
+      //handler doesn't have parameter
+      code:   `import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/index.js'; const onHideHandler = () => {}; <Popover onHide={onHideHandler} />`,
+    },
+    {
       // No @patternfly/react-core import
       code: `<Popover />`,
     }
@@ -50,76 +54,81 @@ ruleTester.run("popover-remove-props", rule, {
     },
     {
       code:   `import { Popover } from '@patternfly/react-core'; <Popover onHidden={tip => {}} onHide={tip => {}} onMount={tip => {}} onShow={tip => {}} onShown={tip => {}} />`,
-      output: `import { Popover } from '@patternfly/react-core'; <Popover onHidden={() => {}} onHide={() => {}} onMount={() => {}} onShow={() => {}} onShown={() => {}} />`,
       errors: [
       {
-        message: "Popover onHidden function's parameter has been removed.",
+        message: "Popover onHidden function's parameter has been removed. Please update your code accordingly.",
         type: "JSXElement",
       },
       {
-        message: "Popover onHide function's parameter has been removed.",
+        message: "Popover onHide function's parameter has been removed. Please update your code accordingly.",
         type: "JSXElement",
       },
       {
-        message: "Popover onMount function's parameter has been removed.",
+        message: "Popover onMount function's parameter has been removed. Please update your code accordingly.",
         type: "JSXElement",
       },
       {
-        message: "Popover onShow function's parameter has been removed.",
+        message: "Popover onShow function's parameter has been removed. Please update your code accordingly.",
         type: "JSXElement",
       },
       {
-        message: "Popover onShown function's parameter has been removed.",
+        message: "Popover onShown function's parameter has been removed. Please update your code accordingly.",
         type: "JSXElement",
       }],
     },
     {
       code:   `import { Popover } from '@patternfly/react-core'; <Popover onHidden={(tip) => {}} onHide={(tip) => {}} onMount={(tip) => {}} onShow={(tip) => {}} onShown={(tip) => {}} />`,
-      output: `import { Popover } from '@patternfly/react-core'; <Popover onHidden={() => {}} onHide={() => {}} onMount={() => {}} onShow={() => {}} onShown={() => {}} />`,
       errors: [
       {
-        message: "Popover onHidden function's parameter has been removed.",
+        message: "Popover onHidden function's parameter has been removed. Please update your code accordingly.",
         type: "JSXElement",
       },
       {
-        message: "Popover onHide function's parameter has been removed.",
+        message: "Popover onHide function's parameter has been removed. Please update your code accordingly.",
         type: "JSXElement",
       },
       {
-        message: "Popover onMount function's parameter has been removed.",
+        message: "Popover onMount function's parameter has been removed. Please update your code accordingly.",
         type: "JSXElement",
       },
       {
-        message: "Popover onShow function's parameter has been removed.",
+        message: "Popover onShow function's parameter has been removed. Please update your code accordingly.",
         type: "JSXElement",
       },
       {
-        message: "Popover onShown function's parameter has been removed.",
+        message: "Popover onShown function's parameter has been removed. Please update your code accordingly.",
         type: "JSXElement",
       }],
     },
     {
       code:   `import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/index.js'; <Popover onHidden={(tip) => {}} onHide={(tip) => {}} onMount={(tip) => {}} onShow={(tip) => {}} onShown={(tip) => {}} />`,
-      output: `import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/index.js'; <Popover onHidden={() => {}} onHide={() => {}} onMount={() => {}} onShow={() => {}} onShown={() => {}} />`,
       errors: [
       {
-        message: "Popover onHidden function's parameter has been removed.",
+        message: "Popover onHidden function's parameter has been removed. Please update your code accordingly.",
         type: "JSXElement",
       },
       {
-        message: "Popover onHide function's parameter has been removed.",
+        message: "Popover onHide function's parameter has been removed. Please update your code accordingly.",
         type: "JSXElement",
       },
       {
-        message: "Popover onMount function's parameter has been removed.",
+        message: "Popover onMount function's parameter has been removed. Please update your code accordingly.",
         type: "JSXElement",
       },
       {
-        message: "Popover onShow function's parameter has been removed.",
+        message: "Popover onShow function's parameter has been removed. Please update your code accordingly.",
         type: "JSXElement",
       },
       {
-        message: "Popover onShown function's parameter has been removed.",
+        message: "Popover onShown function's parameter has been removed. Please update your code accordingly.",
+        type: "JSXElement",
+      }],
+    },
+    {
+      code:   `import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/index.js'; const onHideHandler = (fn) => {}; <Popover onHide={onHideHandler} />`,
+      errors: [
+      {
+        message: "Popover onHide function's parameter has been removed. Please update your code accordingly.",
         type: "JSXElement",
       }],
     }


### PR DESCRIPTION
closes #495 

removes fixers as a developer will have to remove instances of parameter usage as well as the parameter variable itself

fixes issue where using a function variable wasn't working, like

```
const myFunc = (fn) => {};
<Popover onHide={myFunc} />
```