### PR TITLE
fix(Pagination): handle case when titles value is not a direct object expression

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/helpers.js
+++ b/packages/eslint-plugin-pf-codemods/lib/helpers.js
@@ -817,6 +817,19 @@ function getAllJSXElements(context) {
   return jsxElements;
 }
 
+function findVariableDeclaration(name, scope) {
+  while (scope !== null) {
+    const variable = scope.variables.find((v) => v.name === name);
+
+    if (variable) {
+      return variable;
+    }
+
+    scope = scope.upper;
+  }
+  return undefined;
+}
+
 module.exports = {
   createAliasImportSpecifiers,
   ensureImports,
@@ -829,4 +842,5 @@ module.exports = {
   splitSpecifiers,
   addCallbackParam,
   getAllJSXElements,
+  findVariableDeclaration,
 };

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/pagination-rename-props.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/pagination-rename-props.js
@@ -1,4 +1,4 @@
-const { getFromPackage } = require("../../helpers");
+const { getFromPackage, findVariableDeclaration } = require("../../helpers");
 
 module.exports = {
   meta: { fixable: "code" },
@@ -48,42 +48,109 @@ module.exports = {
                 (attribute) => attribute.name?.name === "titles"
               );
 
-              if (titlesProp?.value?.expression?.type === "ObjectExpression") {
-                const updatedTitlesPropNames = {
-                  currPage: "currPageAriaLabel",
-                  paginationTitle: "paginationAriaLabel",
-                  toFirstPage: "toFirstPageAriaLabel",
-                  toLastPage: "toLastPageAriaLabel",
-                  toNextPage: "toNextPageAriaLabel",
-                  toPreviousPage: "toPreviousPageAriaLabel",
-                  optionsToggle: "optionsToggleAriaLabel",
-                };
+              const expr = titlesProp?.value.expression;
 
-                const existingTitlesProps =
-                  titlesProp.value.expression.properties.filter((property) =>
-                    Object.keys(updatedTitlesPropNames).includes(
-                      property.key.name
-                    )
-                  );
+              let toReplace = {
+                currPage: [],
+                paginationTitle: [],
+                toFirstPage: [],
+                toLastPage: [],
+                toNextPage: [],
+                toPreviousPage: [],
+                optionsToggle: [],
+              };
 
-                if (existingTitlesProps.length) {
-                  existingTitlesProps.forEach((existingTitlesProp) => {
-                    const newTitlesPropName =
-                      updatedTitlesPropNames[existingTitlesProp.key.name];
-                    context.report({
-                      node,
-                      message: `The "${existingTitlesProp.key.name}" sub-prop for Pagination's "titles" prop has been renamed to "${newTitlesPropName}".`,
-                      fix(fixer) {
-                        return [
-                          fixer.replaceTextRange(
-                            existingTitlesProp.key.range,
-                            newTitlesPropName
-                          ),
-                        ];
-                      },
-                    });
-                  });
+              const updatedTitlesPropNames = {
+                currPage: "currPageAriaLabel",
+                paginationTitle: "paginationAriaLabel",
+                toFirstPage: "toFirstPageAriaLabel",
+                toLastPage: "toLastPageAriaLabel",
+                toNextPage: "toNextPageAriaLabel",
+                toPreviousPage: "toPreviousPageAriaLabel",
+                optionsToggle: "optionsToggleAriaLabel",
+              };
+
+              const getObjectProp = (expr, propName) =>
+                expr.properties.find(
+                  (prop) =>
+                    (prop.key.type === "Identifier" &&
+                      prop.key.name === propName) ||
+                    (prop.key.type === "Literal" && prop.key.value === propName)
+                );
+
+              const handleObjectExpression = (expr, toReplace) => {
+                for (const propName in updatedTitlesPropNames) {
+                  const prop = getObjectProp(expr, propName);
+                  prop && toReplace[propName].push(prop.key);
+
+                  if (prop?.shorthand) {
+                    const variable = findVariableDeclaration(
+                      propName,
+                      context.getSourceCode().getScope(expr)
+                    );
+
+                    variable &&
+                      toReplace[propName].push(variable.defs[0].node.id);
+                  }
                 }
+              };
+
+              if (expr?.type === "ObjectExpression") {
+                handleObjectExpression(expr, toReplace);
+              }
+
+              if (expr?.type === "Identifier") {
+                const variable = findVariableDeclaration(
+                  expr.name,
+                  context.getSourceCode().getScope(node)
+                );
+
+                const variableValue = variable.defs[0].node.init;
+
+                if (variableValue?.type === "ObjectExpression") {
+                  handleObjectExpression(variableValue, toReplace);
+                }
+
+                const nodesUsingVariable = variable.references.map(
+                  (ref) => ref.identifier.parent
+                );
+
+                nodesUsingVariable.forEach((n) => {
+                  if (n.type === "MemberExpression") {
+                    const propName = n.property.name
+                      ? n.property.name
+                      : n.property.value;
+
+                    propName in updatedTitlesPropNames &&
+                      toReplace[propName].push(n.property);
+                  }
+
+                  if (
+                    n.type === "AssignmentExpression" &&
+                    n.right.type === "ObjectExpression"
+                  ) {
+                    handleObjectExpression(n.right, toReplace);
+                  }
+                });
+              }
+
+              for (const oldName in toReplace) {
+                const replacements = toReplace[oldName];
+                const newName = updatedTitlesPropNames[oldName];
+
+                replacements.length &&
+                  context.report({
+                    message: `The "${oldName}" sub-prop for Pagination's "titles" prop has been renamed to "${newName}".`,
+                    node,
+                    fix: function (fixer) {
+                      return replacements.map((val) =>
+                        fixer.replaceText(
+                          val,
+                          val.type === "Literal" ? `"${newName}"` : newName
+                        )
+                      );
+                    },
+                  });
               }
             }
           },

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/pagination-rename-props.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/pagination-rename-props.js
@@ -1,10 +1,6 @@
 const ruleTester = require("../../ruletester");
 const rule = require("../../../lib/rules/v5/pagination-rename-props");
 
-const updatedPropNames = {
-  perPageComponent: "",
-  defaultToFullPage: "isLastPageShown",
-};
 const updatedTitlesPropNames = {
   currPage: "currPageAriaLabel",
   paginationTitle: "paginationAriaLabel",
@@ -110,6 +106,66 @@ ruleTester.run("pagination-rename-props", rule, {
         },
         {
           message: `The "${titlesPropName}" sub-prop for Pagination's "titles" prop has been renamed to "${updatedTitlesPropNames[titlesPropName]}".`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    })),
+    ...Object.keys(updatedTitlesPropNames).map((oldName) => ({
+      code: `import * as React from "react";
+      import { Pagination } from "@patternfly/react-core";
+      
+      let titlesObject = {
+        ${oldName}: "test",
+      };
+      
+      titlesObject.${oldName} = "test";
+      titlesObject["${oldName}"] = "test";
+      titlesObject = {
+        ${oldName}: "test",
+      };
+      
+      <Pagination titles={titlesObject} />;
+      `,
+      output: `import * as React from "react";
+      import { Pagination } from "@patternfly/react-core";
+      
+      let titlesObject = {
+        ${updatedTitlesPropNames[oldName]}: "test",
+      };
+      
+      titlesObject.${updatedTitlesPropNames[oldName]} = "test";
+      titlesObject["${updatedTitlesPropNames[oldName]}"] = "test";
+      titlesObject = {
+        ${updatedTitlesPropNames[oldName]}: "test",
+      };
+      
+      <Pagination titles={titlesObject} />;
+      `,
+      errors: [
+        {
+          message: `The "${oldName}" sub-prop for Pagination's "titles" prop has been renamed to "${updatedTitlesPropNames[oldName]}".`,
+          type: "JSXOpeningElement",
+        },
+      ],
+    })),
+    ...Object.keys(updatedTitlesPropNames).map((oldName) => ({
+      code: `import * as React from "react";
+      import { Pagination } from "@patternfly/react-core";
+      
+      const ${oldName} = "test";
+      const titlesObject2 = {${oldName}};
+      
+      <Pagination titles={titlesObject2} />;`,
+      output: `import * as React from "react";
+      import { Pagination } from "@patternfly/react-core";
+      
+      const ${updatedTitlesPropNames[oldName]} = "test";
+      const titlesObject2 = {${updatedTitlesPropNames[oldName]}};
+      
+      <Pagination titles={titlesObject2} />;`,
+      errors: [
+        {
+          message: `The "${oldName}" sub-prop for Pagination's "titles" prop has been renamed to "${updatedTitlesPropNames[oldName]}".`,
           type: "JSXOpeningElement",
         },
       ],

--- a/packages/eslint-plugin-pf-codemods/test/rules/v5/pagination-rename-props.js
+++ b/packages/eslint-plugin-pf-codemods/test/rules/v5/pagination-rename-props.js
@@ -111,8 +111,7 @@ ruleTester.run("pagination-rename-props", rule, {
       ],
     })),
     ...Object.keys(updatedTitlesPropNames).map((oldName) => ({
-      code: `import * as React from "react";
-      import { Pagination } from "@patternfly/react-core";
+      code: `import { Pagination } from "@patternfly/react-core";
       
       let titlesObject = {
         ${oldName}: "test",
@@ -126,8 +125,7 @@ ruleTester.run("pagination-rename-props", rule, {
       
       <Pagination titles={titlesObject} />;
       `,
-      output: `import * as React from "react";
-      import { Pagination } from "@patternfly/react-core";
+      output: `import { Pagination } from "@patternfly/react-core";
       
       let titlesObject = {
         ${updatedTitlesPropNames[oldName]}: "test",
@@ -149,15 +147,13 @@ ruleTester.run("pagination-rename-props", rule, {
       ],
     })),
     ...Object.keys(updatedTitlesPropNames).map((oldName) => ({
-      code: `import * as React from "react";
-      import { Pagination } from "@patternfly/react-core";
+      code: `import { Pagination } from "@patternfly/react-core";
       
       const ${oldName} = "test";
       const titlesObject2 = {${oldName}};
       
       <Pagination titles={titlesObject2} />;`,
-      output: `import * as React from "react";
-      import { Pagination } from "@patternfly/react-core";
+      output: `import { Pagination } from "@patternfly/react-core";
       
       const ${updatedTitlesPropNames[oldName]} = "test";
       const titlesObject2 = {${updatedTitlesPropNames[oldName]}};


### PR DESCRIPTION
Closes https://github.com/patternfly/pf-codemods/issues/508

Should cover most cases, where `titles` value is not a direct object expression.

This will be fixed correctly:

```
import * as React from "react";
import { Pagination } from "@patternfly/react-core";

let titlesObject = {
  currPage: "test",
  paginationTitle: "test",
  toFirstPage: "test",
  toLastPage: "test",
  toNextPage: "test",
  toPreviousPage: "test",
  optionsToggle: "test",
};

titlesObject.paginationTitle = "test";
titlesObject["paginationTitle"] = "test";
titlesObject = {
  currPage: "test",
  paginationTitle: "test",
  toFirstPage: "test",
  toLastPage: "test",
  toNextPage: "test",
  toPreviousPage: "test",
  optionsToggle: "test",
};

<Pagination titles={titlesObject} />;

<Pagination
  titles={{
    currPage: "test",
    paginationTitle: "test",
    toFirstPage: "test",
    toLastPage: "test",
    toNextPage: "test",
    toPreviousPage: "test",
    optionsToggle: "test",
  }}
/>;

const paginationTitle = "test";
const titlesObject2 = {paginationTitle};

<Pagination titles={titlesObject2} />;
```

to this:

```
import * as React from "react";
import { Pagination } from "@patternfly/react-core";

let titlesObject = {
  currPageAriaLabel: "test",
  paginationAriaLabel: "test",
  toFirstPageAriaLabel: "test",
  toLastPageAriaLabel: "test",
  toNextPageAriaLabel: "test",
  toPreviousPageAriaLabel: "test",
  optionsToggleAriaLabel: "test",
};

titlesObject.paginationAriaLabel = "test";
titlesObject["paginationAriaLabel"] = "test";
titlesObject = {
  currPageAriaLabel: "test",
  paginationAriaLabel: "test",
  toFirstPageAriaLabel: "test",
  toLastPageAriaLabel: "test",
  toNextPageAriaLabel: "test",
  toPreviousPageAriaLabel: "test",
  optionsToggleAriaLabel: "test",
};

<Pagination titles={titlesObject} />;

<Pagination
  titles={{
    currPageAriaLabel: "test",
    paginationAriaLabel: "test",
    toFirstPageAriaLabel: "test",
    toLastPageAriaLabel: "test",
    toNextPageAriaLabel: "test",
    toPreviousPageAriaLabel: "test",
    optionsToggleAriaLabel: "test",
  }}
/>;

const paginationAriaLabel = "test";
const titlesObject2 = {paginationAriaLabel};

<Pagination titles={titlesObject2} />;
```
