### PR TITLE
fix(helpers): addCallbackParam fix for MemberExpression nodes

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/helpers.js
+++ b/packages/eslint-plugin-pf-codemods/lib/helpers.js
@@ -795,20 +795,23 @@ function addCallbackParam(
                           return fixes;
                         }
 
-                        const replacementParams = `${newParam}, ${context
-                          .getSourceCode()
-                          .getText(params[0])}`;
+                        const paramsToText = (paramsList) =>
+                          paramsList
+                            .map((p) => context.getSourceCode().getText(p))
+                            .join(", ");
+
+                        const newParamsText = `${newParam}, ${paramsToText(
+                          params.filter((p) => p.name !== newParam)
+                        )}`;
 
                         fixes.push(
                           fixer.replaceText(
                             propProperties.memberExpression,
-                            `(${replacementParams}) => ${context
+                            `(${newParamsText}) => ${context
                               .getSourceCode()
                               .getText(
                                 propProperties.memberExpression
-                              )}(${params
-                              .map((p) => context.getSourceCode().getText(p))
-                              .join(", ")})`
+                              )}(${paramsToText(params)})`
                           )
                         );
                       } else {

--- a/packages/eslint-plugin-pf-codemods/lib/helpers.js
+++ b/packages/eslint-plugin-pf-codemods/lib/helpers.js
@@ -747,7 +747,7 @@ function addCallbackParam(
                     params?.length && params[previousParamIndex]?.name;
 
                   // if the expected index of the newParam exceeds the number of current params just set treat it like a param addition with the default param value
-                  if (previousParamIndex >= params?.length) {
+                  if ((previousParamIndex >= params?.length) || !params?.length) {
                     newParam = defaultParamName;
                   }
 

--- a/packages/eslint-plugin-pf-codemods/lib/helpers.js
+++ b/packages/eslint-plugin-pf-codemods/lib/helpers.js
@@ -655,17 +655,17 @@ function addCallbackParam(
                       ? matchingDefinition?.node?.params
                       : matchingDefinition?.node?.init?.params;
                 } else if (propProperties.type === "MemberExpression") {
-                  const memberExpression = attribute.value.expression;
+                  const memberExpression = attribute.value?.expression;
                   if (memberExpression.object.type === "ThisExpression") {
                     const parentClass = findParentClass(memberExpression);
-                    const methods = parentClass.body.body;
-                    const methodDefinition = methods.find(
+                    const methods = parentClass?.body?.body;
+                    const methodDefinition = methods?.find(
                       (method) =>
                         method.key.type === "Identifier" &&
                         method.key.name === memberExpression.property.name
                     );
 
-                    propProperties.params = methodDefinition.value?.params;
+                    propProperties.params = methodDefinition?.value?.params;
                     propProperties.memberExpression = memberExpression;
                   }
                 }
@@ -782,16 +782,6 @@ function addCallbackParam(
                         return fixer.replaceTextRange(targetRange, "");
                       };
 
-                      if (
-                        ![
-                          "ArrowFunctionExpression",
-                          "Identifier",
-                          "MemberExpression",
-                        ].includes(type)
-                      ) {
-                        return fixes;
-                      }
-
                       const currentIndexOfNewParam = params?.findIndex(
                         (param) => param.name === newParam
                       );
@@ -800,6 +790,10 @@ function addCallbackParam(
                         type === "MemberExpression" &&
                         propProperties.hasOwnProperty("memberExpression")
                       ) {
+                        if (!params || params.length === 0) {
+                          return fixes;
+                        }
+
                         const replacementParams = `${newParam}, ${context
                           .getSourceCode()
                           .getText(params[0])}`;

--- a/packages/eslint-plugin-pf-codemods/lib/helpers.js
+++ b/packages/eslint-plugin-pf-codemods/lib/helpers.js
@@ -656,11 +656,12 @@ function addCallbackParam(
                       ? matchingDefinition?.node?.params
                       : matchingDefinition?.node?.init?.params;
 
-                  if (
-                    matchingDefinition?.type === "Variable" &&
-                    matchingDefinition?.node.id?.type === "ArrayPattern" &&
-                    matchingDefinition?.node.init?.type === "CallExpression"
-                  ) {
+                  const isPotentialUseStateHook = (definition) =>
+                    definition?.type === "Variable" &&
+                    definition?.node.id?.type === "ArrayPattern" &&
+                    definition?.node.init?.type === "CallExpression";
+
+                  if (isPotentialUseStateHook(matchingDefinition)) {
                     const callee = matchingDefinition?.node.init.callee;
                     const reactImports = getFromPackage(
                       context,
@@ -747,7 +748,7 @@ function addCallbackParam(
                     params?.length && params[previousParamIndex]?.name;
 
                   // if the expected index of the newParam exceeds the number of current params just set treat it like a param addition with the default param value
-                  if ((previousParamIndex >= params?.length) || !params?.length) {
+                  if (previousParamIndex >= params?.length || !params?.length) {
                     newParam = defaultParamName;
                   }
 

--- a/packages/eslint-plugin-pf-codemods/lib/helpers.js
+++ b/packages/eslint-plugin-pf-codemods/lib/helpers.js
@@ -656,14 +656,26 @@ function addCallbackParam(
                     matchingDefinition?.node.init.type === "CallExpression"
                   ) {
                     const callee = matchingDefinition?.node.init.callee;
+                    const reactImports = getFromPackage(
+                      context,
+                      "react"
+                    ).imports;
+
+                    const defaultSpecifierName = reactImports.find(
+                      (spec) => spec.type === "ImportDefaultSpecifier"
+                    )?.local.name;
+
+                    const useStateLocalName = reactImports.find(
+                      (spec) => spec.imported?.name === "useState"
+                    )?.local.name;
+
                     if (
                       (callee.type === "Identifier" &&
-                        callee.name === "useState") ||
+                        callee.name === useStateLocalName) ||
                       (callee.type === "MemberExpression" &&
-                        callee.object.name === "React" &&
+                        callee.object.name === defaultSpecifierName &&
                         callee.property.name === "useState")
                     ) {
-                      console.log("hereeee");
                       propProperties.stateSetterToReplace =
                         attribute.value?.expression;
                     }

--- a/packages/eslint-plugin-pf-codemods/lib/helpers.js
+++ b/packages/eslint-plugin-pf-codemods/lib/helpers.js
@@ -786,11 +786,12 @@ function addCallbackParam(
                         (param) => param.name === newParam
                       );
 
-                      if (
-                        type === "MemberExpression" &&
-                        propProperties.hasOwnProperty("memberExpression")
-                      ) {
-                        if (!params || params.length === 0) {
+                      if (type === "MemberExpression") {
+                        if (
+                          !propProperties.hasOwnProperty("memberExpression") ||
+                          !params ||
+                          params.length === 0
+                        ) {
                           return fixes;
                         }
 

--- a/packages/eslint-plugin-pf-codemods/lib/helpers.js
+++ b/packages/eslint-plugin-pf-codemods/lib/helpers.js
@@ -658,8 +658,8 @@ function addCallbackParam(
 
                   if (
                     matchingDefinition?.type === "Variable" &&
-                    matchingDefinition?.node.id.type === "ArrayPattern" &&
-                    matchingDefinition?.node.init.type === "CallExpression"
+                    matchingDefinition?.node.id?.type === "ArrayPattern" &&
+                    matchingDefinition?.node.init?.type === "CallExpression"
                   ) {
                     const callee = matchingDefinition?.node.init.callee;
                     const reactImports = getFromPackage(
@@ -675,13 +675,14 @@ function addCallbackParam(
                       (spec) => spec.imported?.name === "useState"
                     )?.local.name;
 
-                    if (
+                    const isStateSetter = (callee) =>
                       (callee.type === "Identifier" &&
                         callee.name === useStateLocalName) ||
                       (callee.type === "MemberExpression" &&
                         callee.object.name === defaultSpecifierName &&
-                        callee.property.name === "useState")
-                    ) {
+                        callee.property.name === "useState");
+
+                    if (isStateSetter(callee)) {
                       propProperties.isStateSetter = true;
                       propProperties.stateType =
                         matchingDefinition?.node.init.typeParameters?.params[0].typeName?.name;
@@ -772,8 +773,8 @@ function addCallbackParam(
                 if (
                   (params?.length >= 1 &&
                     ["ArrowFunctionExpression", "Identifier"].includes(type)) ||
-                  propProperties.hasOwnProperty("isThisExpression") ||
-                  propProperties.hasOwnProperty("isStateSetter")
+                  propProperties.isThisExpression ||
+                  propProperties.isStateSetter
                 ) {
                   context.report({
                     node,
@@ -785,7 +786,7 @@ function addCallbackParam(
                     fix(fixer) {
                       const fixes = [];
 
-                      if (propProperties.hasOwnProperty("isStateSetter")) {
+                      if (propProperties.isStateSetter) {
                         const typeText = propProperties.stateType
                           ? `: ${propProperties.stateType}`
                           : "";
@@ -796,7 +797,7 @@ function addCallbackParam(
                           )
                         );
                       } else if (
-                        propProperties.hasOwnProperty("isThisExpression") ||
+                        propProperties.isThisExpression ||
                         type === "Identifier"
                       ) {
                         if (!params || params.length === 0) {

--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/popover-remove-props.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/popover-remove-props.js
@@ -53,7 +53,7 @@ module.exports = {
             }
 
             // only report if 3 are passed or one has tip in name
-            if(params?.length === 3 || params.some( (p) => /tip/i.test("" + p.name))) {
+            if(params?.length === 3 || params?.some( (p) => /tip/i.test("" + p.name))) {
               context.report({
                 node,
                 message: "Popover shouldClose function's tip parameter has been removed. Please update accordingly",

--- a/packages/eslint-plugin-pf-codemods/test/testHelpers.js
+++ b/packages/eslint-plugin-pf-codemods/test/testHelpers.js
@@ -164,7 +164,7 @@ function getInvalidAddCallbackParamTests(
       });
       tests.push({
         code: `import { ${componentName} as ${componentName}Deprecated } from '@patternfly/react-core/deprecated'; const handler = (id) => {}; <${componentName}Deprecated ${propName}={handler} />;`,
-        output: `import { ${componentName} as ${componentName}Deprecated } from '@patternfly/react-core/deprecated'; const handler = (${newParamName}, id) => {}; <${componentName}Deprecated ${propName}={handler} />;`,
+        output: `import { ${componentName} as ${componentName}Deprecated } from '@patternfly/react-core/deprecated'; const handler = (id) => {}; <${componentName}Deprecated ${propName}={(${newParamName}, id) => handler(id)} />;`,
         errors: [
           {
             message: createMessageCallback(
@@ -178,7 +178,7 @@ function getInvalidAddCallbackParamTests(
       });
       tests.push({
         code: `import { ${componentName} } from '@patternfly/react-core'; const handler = (id: bar) => {}; <${componentName} ${propName}={handler} />;`,
-        output: `import { ${componentName} } from '@patternfly/react-core'; const handler = (${newParamName}, id: bar) => {}; <${componentName} ${propName}={handler} />;`,
+        output: `import { ${componentName} } from '@patternfly/react-core'; const handler = (id: bar) => {}; <${componentName} ${propName}={(${newParamName}, id: bar) => handler(id)} />;`,
         errors: [
           {
             message: createMessageCallback(
@@ -192,7 +192,7 @@ function getInvalidAddCallbackParamTests(
       });
       tests.push({
         code: `import { ${componentName} } from '@patternfly/react-core'; function handler(id) {}; <${componentName} ${propName}={handler} />;`,
-        output: `import { ${componentName} } from '@patternfly/react-core'; function handler(${newParamName}, id) {}; <${componentName} ${propName}={handler} />;`,
+        output: `import { ${componentName} } from '@patternfly/react-core'; function handler(id) {}; <${componentName} ${propName}={(${newParamName}, id) => handler(id)} />;`,
         errors: [
           {
             message: createMessageCallback(
@@ -206,21 +206,7 @@ function getInvalidAddCallbackParamTests(
       });
       tests.push({
         code: `import { ${componentName} } from '@patternfly/react-core'; function handler(id: bar) {}; <${componentName} ${propName}={handler} />;`,
-        output: `import { ${componentName} } from '@patternfly/react-core'; function handler(${newParamName}, id: bar) {}; <${componentName} ${propName}={handler} />;`,
-        errors: [
-          {
-            message: createMessageCallback(
-              componentName,
-              propName,
-              newParamName
-            ),
-            type: "JSXOpeningElement",
-          },
-        ],
-      });
-      tests.push({
-        code: `import { ${componentName} } from '@patternfly/react-core'; <${componentName} ${propName}={this.handler} />;`,
-        output: `import { ${componentName} } from '@patternfly/react-core'; <${componentName} ${propName}={this.handler} />;`,
+        output: `import { ${componentName} } from '@patternfly/react-core'; function handler(id: bar) {}; <${componentName} ${propName}={(${newParamName}, id: bar) => handler(id)} />;`,
         errors: [
           {
             message: createMessageCallback(
@@ -279,7 +265,7 @@ function getInvalidAddCallbackParamTests(
         });
         tests.push({
           code: `import { ${componentName} } from '@patternfly/react-core'; const handler = (id, text) => {}; <${componentName} ${propName}={handler} />;`,
-          output: `import { ${componentName} } from '@patternfly/react-core'; const handler = (${newParamName}, id, text) => {}; <${componentName} ${propName}={handler} />;`,
+          output: `import { ${componentName} } from '@patternfly/react-core'; const handler = (id, text) => {}; <${componentName} ${propName}={(${newParamName}, id, text) => handler(id, text)} />;`,
           errors: [
             {
               message: createMessageCallback(
@@ -293,7 +279,7 @@ function getInvalidAddCallbackParamTests(
         });
         tests.push({
           code: `import { ${componentName} } from '@patternfly/react-core'; function handler(id, text) {}; <${componentName} ${propName}={handler} />;`,
-          output: `import { ${componentName} } from '@patternfly/react-core'; function handler(${newParamName}, id, text) {}; <${componentName} ${propName}={handler} />;`,
+          output: `import { ${componentName} } from '@patternfly/react-core'; function handler(id, text) {}; <${componentName} ${propName}={(${newParamName}, id, text) => handler(id, text)} />;`,
           errors: [
             {
               message: createMessageCallback(
@@ -372,7 +358,7 @@ function getInvalidSwapCallbackParamTests(
 
           tests.push({
             code: `import { ${componentName} } from '@patternfly/react-core'; function handler(${initialArgs}) {}; <${componentName} ${propName}={handler} />;`,
-            output: `import { ${componentName} } from '@patternfly/react-core'; function handler(${fixedArgs}) {}; <${componentName} ${propName}={handler} />;`,
+            output: `import { ${componentName} } from '@patternfly/react-core'; function handler(${initialArgs}) {}; <${componentName} ${propName}={(${fixedArgs}) => handler(${initialArgs})} />;`,
             errors: [
               {
                 message: createMessageCallback(
@@ -386,7 +372,7 @@ function getInvalidSwapCallbackParamTests(
           });
           tests.push({
             code: `import { ${componentName} } from '@patternfly/react-core/dist/esm/components/${componentName}/index.js'; function handler(${initialArgs}) {}; <${componentName} ${propName}={handler} />;`,
-            output: `import { ${componentName} } from '@patternfly/react-core/dist/esm/components/${componentName}/index.js'; function handler(${fixedArgs}) {}; <${componentName} ${propName}={handler} />;`,
+            output: `import { ${componentName} } from '@patternfly/react-core/dist/esm/components/${componentName}/index.js'; function handler(${initialArgs}) {}; <${componentName} ${propName}={(${fixedArgs}) => handler(${initialArgs})} />;`,
             errors: [
               {
                 message: createMessageCallback(

--- a/packages/eslint-plugin-pf-codemods/test/testHelpers.js
+++ b/packages/eslint-plugin-pf-codemods/test/testHelpers.js
@@ -305,6 +305,94 @@ function getInvalidAddCallbackParamTests(
             },
           ],
         });
+        tests.push({
+          code: `import { ${componentName} } from '@patternfly/react-core'; import React from "react";
+          const SimpleComponent = () => {
+            const [count, setCount] = React.useState(0);
+            return <${componentName} ${propName}={setCount} />;
+          };`,
+          output: `import { ${componentName} } from '@patternfly/react-core'; import React from "react";
+          const SimpleComponent = () => {
+            const [count, setCount] = React.useState(0);
+            return <${componentName} ${propName}={(_event, val) => setCount(val)} />;
+          };`,
+          errors: [
+            {
+              message: createMessageCallback(
+                componentName,
+                propName,
+                newParamName
+              ),
+              type: "JSXOpeningElement",
+            },
+          ],
+        });
+        tests.push({
+          code: `import { ${componentName} } from '@patternfly/react-core'; import { useState } from "react";
+          const SimpleComponent = () => {
+            const [count, setCount] = useState(0);
+            return <${componentName} ${propName}={setCount} />;
+          };`,
+          output: `import { ${componentName} } from '@patternfly/react-core'; import { useState } from "react";
+          const SimpleComponent = () => {
+            const [count, setCount] = useState(0);
+            return <${componentName} ${propName}={(_event, val) => setCount(val)} />;
+          };`,
+          errors: [
+            {
+              message: createMessageCallback(
+                componentName,
+                propName,
+                newParamName
+              ),
+              type: "JSXOpeningElement",
+            },
+          ],
+        });
+        tests.push({
+          code: `import { ${componentName} } from '@patternfly/react-core'; import React from "react";
+          const SimpleComponent = () => {
+            const [count, setCount] = React.useState<Number>(0);
+            return <${componentName} ${propName}={setCount} />;
+          };`,
+          output: `import { ${componentName} } from '@patternfly/react-core'; import React from "react";
+          const SimpleComponent = () => {
+            const [count, setCount] = React.useState<Number>(0);
+            return <${componentName} ${propName}={(_event, val: Number) => setCount(val)} />;
+          };`,
+          errors: [
+            {
+              message: createMessageCallback(
+                componentName,
+                propName,
+                newParamName
+              ),
+              type: "JSXOpeningElement",
+            },
+          ],
+        });
+        tests.push({
+          code: `import { ${componentName} } from '@patternfly/react-core'; import { useState } from "react";
+          const SimpleComponent = () => {
+            const [count, setCount] = useState<Number>(0);
+            return <${componentName} ${propName}={setCount} />;
+          };`,
+          output: `import { ${componentName} } from '@patternfly/react-core'; import { useState } from "react";
+          const SimpleComponent = () => {
+            const [count, setCount] = useState<Number>(0);
+            return <${componentName} ${propName}={(_event, val: Number) => setCount(val)} />;
+          };`,
+          errors: [
+            {
+              message: createMessageCallback(
+                componentName,
+                propName,
+                newParamName
+              ),
+              type: "JSXOpeningElement",
+            },
+          ],
+        });
       }
     });
   });

--- a/packages/eslint-plugin-pf-codemods/test/testHelpers.js
+++ b/packages/eslint-plugin-pf-codemods/test/testHelpers.js
@@ -307,97 +307,94 @@ function getInvalidAddCallbackParamTests(
         });
       }
 
-      // tests only for param addition in case of converting stateSetter to an arrow function calling the stateSetter
-      if (!previousParamIndex) {
-        tests.push({
-          code: `import { ${componentName} } from '@patternfly/react-core'; import React from "react";
-          const SimpleComponent = () => {
-            const [count, setCount] = React.useState(0);
-            return <${componentName} ${propName}={setCount} />;
-          };`,
-          output: `import { ${componentName} } from '@patternfly/react-core'; import React from "react";
-          const SimpleComponent = () => {
-            const [count, setCount] = React.useState(0);
-            return <${componentName} ${propName}={(_event, val) => setCount(val)} />;
-          };`,
-          errors: [
-            {
-              message: createMessageCallback(
-                componentName,
-                propName,
-                newParamName
-              ),
-              type: "JSXOpeningElement",
-            },
-          ],
-        });
-        tests.push({
-          code: `import { ${componentName} } from '@patternfly/react-core'; import { useState } from "react";
-          const SimpleComponent = () => {
-            const [count, setCount] = useState(0);
-            return <${componentName} ${propName}={setCount} />;
-          };`,
-          output: `import { ${componentName} } from '@patternfly/react-core'; import { useState } from "react";
-          const SimpleComponent = () => {
-            const [count, setCount] = useState(0);
-            return <${componentName} ${propName}={(_event, val) => setCount(val)} />;
-          };`,
-          errors: [
-            {
-              message: createMessageCallback(
-                componentName,
-                propName,
-                newParamName
-              ),
-              type: "JSXOpeningElement",
-            },
-          ],
-        });
-        tests.push({
-          code: `import { ${componentName} } from '@patternfly/react-core'; import React from "react";
-          const SimpleComponent = () => {
-            const [count, setCount] = React.useState<Number>(0);
-            return <${componentName} ${propName}={setCount} />;
-          };`,
-          output: `import { ${componentName} } from '@patternfly/react-core'; import React from "react";
-          const SimpleComponent = () => {
-            const [count, setCount] = React.useState<Number>(0);
-            return <${componentName} ${propName}={(_event, val: Number) => setCount(val)} />;
-          };`,
-          errors: [
-            {
-              message: createMessageCallback(
-                componentName,
-                propName,
-                newParamName
-              ),
-              type: "JSXOpeningElement",
-            },
-          ],
-        });
-        tests.push({
-          code: `import { ${componentName} } from '@patternfly/react-core'; import { useState } from "react";
-          const SimpleComponent = () => {
-            const [count, setCount] = useState<Number>(0);
-            return <${componentName} ${propName}={setCount} />;
-          };`,
-          output: `import { ${componentName} } from '@patternfly/react-core'; import { useState } from "react";
-          const SimpleComponent = () => {
-            const [count, setCount] = useState<Number>(0);
-            return <${componentName} ${propName}={(_event, val: Number) => setCount(val)} />;
-          };`,
-          errors: [
-            {
-              message: createMessageCallback(
-                componentName,
-                propName,
-                newParamName
-              ),
-              type: "JSXOpeningElement",
-            },
-          ],
-        });
-      }
+      tests.push({
+        code: `import { ${componentName} } from '@patternfly/react-core'; import React from "react";
+        const SimpleComponent = () => {
+          const [count, setCount] = React.useState(0);
+          return <${componentName} ${propName}={setCount} />;
+        };`,
+        output: `import { ${componentName} } from '@patternfly/react-core'; import React from "react";
+        const SimpleComponent = () => {
+          const [count, setCount] = React.useState(0);
+          return <${componentName} ${propName}={(_event, val) => setCount(val)} />;
+        };`,
+        errors: [
+          {
+            message: createMessageCallback(
+              componentName,
+              propName,
+              newParamName
+            ),
+            type: "JSXOpeningElement",
+          },
+        ],
+      });
+      tests.push({
+        code: `import { ${componentName} } from '@patternfly/react-core'; import { useState } from "react";
+        const SimpleComponent = () => {
+          const [count, setCount] = useState(0);
+          return <${componentName} ${propName}={setCount} />;
+        };`,
+        output: `import { ${componentName} } from '@patternfly/react-core'; import { useState } from "react";
+        const SimpleComponent = () => {
+          const [count, setCount] = useState(0);
+          return <${componentName} ${propName}={(_event, val) => setCount(val)} />;
+        };`,
+        errors: [
+          {
+            message: createMessageCallback(
+              componentName,
+              propName,
+              newParamName
+            ),
+            type: "JSXOpeningElement",
+          },
+        ],
+      });
+      tests.push({
+        code: `import { ${componentName} } from '@patternfly/react-core'; import React from "react";
+        const SimpleComponent = () => {
+          const [count, setCount] = React.useState<Number>(0);
+          return <${componentName} ${propName}={setCount} />;
+        };`,
+        output: `import { ${componentName} } from '@patternfly/react-core'; import React from "react";
+        const SimpleComponent = () => {
+          const [count, setCount] = React.useState<Number>(0);
+          return <${componentName} ${propName}={(_event, val: Number) => setCount(val)} />;
+        };`,
+        errors: [
+          {
+            message: createMessageCallback(
+              componentName,
+              propName,
+              newParamName
+            ),
+            type: "JSXOpeningElement",
+          },
+        ],
+      });
+      tests.push({
+        code: `import { ${componentName} } from '@patternfly/react-core'; import { useState } from "react";
+        const SimpleComponent = () => {
+          const [count, setCount] = useState<Number>(0);
+          return <${componentName} ${propName}={setCount} />;
+        };`,
+        output: `import { ${componentName} } from '@patternfly/react-core'; import { useState } from "react";
+        const SimpleComponent = () => {
+          const [count, setCount] = useState<Number>(0);
+          return <${componentName} ${propName}={(_event, val: Number) => setCount(val)} />;
+        };`,
+        errors: [
+          {
+            message: createMessageCallback(
+              componentName,
+              propName,
+              newParamName
+            ),
+            type: "JSXOpeningElement",
+          },
+        ],
+      });
     });
   });
   return tests;

--- a/packages/eslint-plugin-pf-codemods/test/testHelpers.js
+++ b/packages/eslint-plugin-pf-codemods/test/testHelpers.js
@@ -83,6 +83,58 @@ function getInvalidAddCallbackParamTests(
         ],
       });
       tests.push({
+        code: `import { ${componentName} } from '@patternfly/react-core';
+        class MyClass {
+          handleChange(id) {}
+          render() {
+            return <${componentName} ${propName}={this.handleChange} />;
+          }
+        }`,
+        output: `import { ${componentName} } from '@patternfly/react-core';
+        class MyClass {
+          handleChange(id) {}
+          render() {
+            return <${componentName} ${propName}={(${newParamName}, id) => this.handleChange(id)} />;
+          }
+        }`,
+        errors: [
+          {
+            message: createMessageCallback(
+              componentName,
+              propName,
+              newParamName
+            ),
+            type: "JSXOpeningElement",
+          },
+        ],
+      });
+      tests.push({
+        code: `import { ${componentName} } from '@patternfly/react-core/dist/esm/components/${componentName}/index.js';
+        class MyClass {
+          handleChange(id) {}
+          render() {
+            return <${componentName} ${propName}={this.handleChange} />;
+          }
+        }`,
+        output: `import { ${componentName} } from '@patternfly/react-core/dist/esm/components/${componentName}/index.js';
+        class MyClass {
+          handleChange(id) {}
+          render() {
+            return <${componentName} ${propName}={(${newParamName}, id) => this.handleChange(id)} />;
+          }
+        }`,
+        errors: [
+          {
+            message: createMessageCallback(
+              componentName,
+              propName,
+              newParamName
+            ),
+            type: "JSXOpeningElement",
+          },
+        ],
+      });
+      tests.push({
         code: `import { ${componentName} } from '@patternfly/react-core'; <${componentName} ${propName}={(id: bar) => handler(id)} />;`,
         output: `import { ${componentName} } from '@patternfly/react-core'; <${componentName} ${propName}={(${newParamName}, id: bar) => handler(id)} />;`,
         errors: [

--- a/packages/eslint-plugin-pf-codemods/test/testHelpers.js
+++ b/packages/eslint-plugin-pf-codemods/test/testHelpers.js
@@ -305,6 +305,10 @@ function getInvalidAddCallbackParamTests(
             },
           ],
         });
+      }
+
+      // tests only for param addition in case of converting stateSetter to an arrow function calling the stateSetter
+      if (!previousParamIndex) {
         tests.push({
           code: `import { ${componentName} } from '@patternfly/react-core'; import React from "react";
           const SimpleComponent = () => {


### PR DESCRIPTION
Closes #520

fixes callbacks like `onToggle={this.handleToggle}` to `onToggle={(event, value) => this.handleToggle(value, event)}`