### PR TITLE
fix issue with imports that dont have import name

### DIFF
--- a/packages/eslint-plugin-pf-codemods/lib/rules/v5/charts-remove-ChartThemeVariant.js
+++ b/packages/eslint-plugin-pf-codemods/lib/rules/v5/charts-remove-ChartThemeVariant.js
@@ -16,7 +16,7 @@ module.exports = {
             if (
               node.specifiers.find(
                 (specifier) =>
-                  specifier.imported.name ===
+                  specifier.imported?.name ===
                   chartThemeVariantImport[0].imported.name
               )
             )

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import {
   Chart,
   ChartLegend,
@@ -5,6 +6,7 @@ import {
   getCustomTheme,
   getResizeObserver,
   LightBlueColorTheme,
+  ChartThemeVariant,
 } from "@patternfly/react-charts";
 import { CodeEditor } from "@patternfly/react-code-editor";
 import { FrogIcon } from "@patternfly/react-icons";


### PR DESCRIPTION
checked around and this was the only place i could find it checking specifier import.name on items that aren't from a pf repo.

closes #538 