### PR TITLE
fix(datetimepicker): set rule intended to be a warning as a warning

### DIFF
--- a/packages/eslint-plugin-pf-codemods/index.js
+++ b/packages/eslint-plugin-pf-codemods/index.js
@@ -10,7 +10,7 @@ const warningRules = [
   "charts-warn-tooltip",
   "conditional-aria",
   "datePicker-warn-appendTo-default-value-changed",
-  "datepicker-warn-helperText",
+  "datetimepicker-warn-helperText",
   "deprecatedSelect-warn-markupUpdated",
   "emptyState-warn-change-structure",
   "formControls-updated-markup",

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -101,6 +101,7 @@ import {
   TextArea,
   TextInput,
   Title,
+  TimePicker,
   Toggle,
   ToggleGroupItem,
   ToggleTemplateProps,
@@ -326,6 +327,7 @@ const themeClassName = 'pf-theme-dark';
     customIconDimensions
   />
   <TextInput onChange={(foo, event) => handler(foo, event)} />
+  <TimePicker helperText='foo' />
   <Toggle isPrimary onToggle={} />
   <ToggleGroupItem onChange={(foo, event) => handler(foo, event)} />
   <Tooltip />


### PR DESCRIPTION
Fix rule name typo in warningRules array.