### PR TITLE
feat(FormGroup): rename labelIcon to labelHelp

### DIFF
--- a/packages/eslint-plugin-pf-codemods/src/ruleCustomization.ts
+++ b/packages/eslint-plugin-pf-codemods/src/ruleCustomization.ts
@@ -1,5 +1,6 @@
 // if you want your rule to only run when explicitly called for using the --only flag, add the rule name to the below array
 export const betaRuleNames: string[] = [
+  "formGroup-rename-labelIcon",
   "menuItemAction-warn-update-markup",
   "menuToggle-warn-iconOnly-toggle",
 ];

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.md
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.md
@@ -1,0 +1,18 @@
+### formGroup-rename-labelIcon [(#10016)](https://github.com/patternfly/patternfly-react/pull/10016)
+
+The `labelIcon` prop for FormGroup has been renamed to `labelHelp`. We recommend using FormGroupLabelHelp element for the labelHelp prop. The markup has also changed, we now wrap the labelHelp element in `<span className={styles.formGroupLabelHelp}>`, so there is no need to add `className={styles.formGroupLabelHelp}` to the labelHelp element.
+
+#### Examples
+
+In:
+
+```jsx
+%inputExample%
+```
+
+Out:
+
+```jsx
+%outputExample%
+```
+

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.md
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.md
@@ -15,4 +15,3 @@ Out:
 ```jsx
 %outputExample%
 ```
-

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.md
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.md
@@ -1,6 +1,6 @@
 ### formGroup-rename-labelIcon [(#10016)](https://github.com/patternfly/patternfly-react/pull/10016)
 
-The `labelIcon` prop for FormGroup has been renamed to `labelHelp`. We recommend using FormGroupLabelHelp element for the labelHelp prop. The markup has also changed, we now wrap the labelHelp element in `<span className={styles.formGroupLabelHelp}>`, so there is no need to add `className={styles.formGroupLabelHelp}` to the labelHelp element.
+The `labelIcon` prop for FormGroup has been renamed to `labelHelp`. We recommend using FormGroupLabelHelp element for the labelHelp prop. The markup has also changed, we now wrap the labelHelp element in `<span className="pf-v6-c-form__group-label-help">`, so there is no need to add `className="pf-v6-c-form__group-label-help"` to the labelHelp element.
 
 #### Examples
 

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.test.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.test.ts
@@ -1,0 +1,24 @@
+const ruleTester = require('../../ruletester');
+import * as rule from './formGroup-rename-labelIcon';
+
+ruleTester.run("formGroup-rename-labelIcon", rule, {
+  valid: [
+    {
+      code: `<FormGroup labelIcon />`
+    },
+    {
+      code: `import { FormGroup } from '@patternfly/react-core'; <FormGroup someOtherProp />`
+    }
+  ],
+  invalid: [
+    {
+      code:   `import { FormGroup } from '@patternfly/react-core'; <FormGroup labelIcon={<>Help icon</>} />`,
+      output: `import { FormGroup } from '@patternfly/react-core'; <FormGroup labelHelp={<>Help icon</>} />`,
+      errors: [{
+        message: `The \`labelIcon\` prop for FormGroup has been renamed to \`labelHelp\`. We recommend using FormGroupLabelHelp element for the labelHelp prop. The markup has also changed, we now wrap the labelHelp element in \`<span className={styles.formGroupLabelHelp}>\`, so there is no need to add \`className={styles.formGroupLabelHelp}\` to the labelHelp element.`,
+        type: "JSXOpeningElement",
+      }]
+    },
+  ]
+});
+  

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.test.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.test.ts
@@ -1,24 +1,25 @@
-const ruleTester = require('../../ruletester');
-import * as rule from './formGroup-rename-labelIcon';
+const ruleTester = require("../../ruletester");
+import * as rule from "./formGroup-rename-labelIcon";
 
 ruleTester.run("formGroup-rename-labelIcon", rule, {
   valid: [
     {
-      code: `<FormGroup labelIcon />`
+      code: `<FormGroup labelIcon />`,
     },
     {
-      code: `import { FormGroup } from '@patternfly/react-core'; <FormGroup someOtherProp />`
-    }
+      code: `import { FormGroup } from '@patternfly/react-core'; <FormGroup someOtherProp />`,
+    },
   ],
   invalid: [
     {
-      code:   `import { FormGroup } from '@patternfly/react-core'; <FormGroup labelIcon={<>Help icon</>} />`,
+      code: `import { FormGroup } from '@patternfly/react-core'; <FormGroup labelIcon={<>Help icon</>} />`,
       output: `import { FormGroup } from '@patternfly/react-core'; <FormGroup labelHelp={<>Help icon</>} />`,
-      errors: [{
-        message: `The \`labelIcon\` prop for FormGroup has been renamed to \`labelHelp\`. We recommend using FormGroupLabelHelp element for the labelHelp prop. The markup has also changed, we now wrap the labelHelp element in \`<span className={styles.formGroupLabelHelp}>\`, so there is no need to add \`className={styles.formGroupLabelHelp}\` to the labelHelp element.`,
-        type: "JSXOpeningElement",
-      }]
+      errors: [
+        {
+          message: `The \`labelIcon\` prop for FormGroup has been renamed to \`labelHelp\`. We recommend using FormGroupLabelHelp element for the labelHelp prop. The markup has also changed, we now wrap the labelHelp element in \`<span className={styles.formGroupLabelHelp}>\`, so there is no need to add \`className={styles.formGroupLabelHelp}\` to the labelHelp element.`,
+          type: "JSXOpeningElement",
+        },
+      ],
     },
-  ]
+  ],
 });
-  

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.test.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.test.ts
@@ -16,7 +16,7 @@ ruleTester.run("formGroup-rename-labelIcon", rule, {
       output: `import { FormGroup } from '@patternfly/react-core'; <FormGroup labelHelp={<>Help icon</>} />`,
       errors: [
         {
-          message: `The \`labelIcon\` prop for FormGroup has been renamed to \`labelHelp\`. We recommend using FormGroupLabelHelp element for the labelHelp prop. The markup has also changed, we now wrap the labelHelp element in \`<span className={styles.formGroupLabelHelp}>\`, so there is no need to add \`className={styles.formGroupLabelHelp}\` to the labelHelp element.`,
+          message: `The \`labelIcon\` prop for FormGroup has been renamed to \`labelHelp\`. We recommend using FormGroupLabelHelp element for the labelHelp prop. The markup has also changed, we now wrap the labelHelp element in \`<span className="pf-v6-c-form__group-label-help">\`, so there is no need to add \`className="pf-v6-c-form__group-label-help"\` to the labelHelp element.`,
           type: "JSXOpeningElement",
         },
       ],

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.ts
@@ -7,7 +7,7 @@ module.exports = {
     FormGroup: {
       labelIcon: {
         newName: "labelHelp",
-        message: `The \`labelIcon\` prop for FormGroup has been renamed to \`labelHelp\`. We recommend using FormGroupLabelHelp element for the labelHelp prop. The markup has also changed, we now wrap the labelHelp element in \`<span className={styles.formGroupLabelHelp}>\`, so there is no need to add \`className={styles.formGroupLabelHelp}\` to the labelHelp element.`,
+        message: `The \`labelIcon\` prop for FormGroup has been renamed to \`labelHelp\`. We recommend using FormGroupLabelHelp element for the labelHelp prop. The markup has also changed, we now wrap the labelHelp element in \`<span className="pf-v6-c-form__group-label-help">\`, so there is no need to add \`className="pf-v6-c-form__group-label-help"\` to the labelHelp element.`,
       },
     },
   }),

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroup-rename-labelIcon.ts
@@ -1,0 +1,14 @@
+import { renameProps } from "../../helpers";
+
+// https://github.com/patternfly/patternfly-react/pull/10016
+module.exports = {
+  meta: { fixable: "code" },
+  create: renameProps({
+    FormGroup: {
+      labelIcon: {
+        newName: "labelHelp",
+        message: `The \`labelIcon\` prop for FormGroup has been renamed to \`labelHelp\`. We recommend using FormGroupLabelHelp element for the labelHelp prop. The markup has also changed, we now wrap the labelHelp element in \`<span className={styles.formGroupLabelHelp}>\`, so there is no need to add \`className={styles.formGroupLabelHelp}\` to the labelHelp element.`,
+      },
+    },
+  }),
+};

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroupRenameLabelIconInput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroupRenameLabelIconInput.tsx
@@ -1,0 +1,5 @@
+import { FormGroup } from "@patternfly/react-core";
+
+export const FormGroupRenameLabelIconInput = () => (
+  <FormGroup labelIcon={<>Help icon</>} />
+);

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroupRenameLabelIconOutput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/formGroupRenameLabelIcon/formGroupRenameLabelIconOutput.tsx
@@ -1,0 +1,5 @@
+import { FormGroup } from "@patternfly/react-core";
+
+export const FormGroupRenameLabelIconInput = () => (
+  <FormGroup labelHelp={<>Help icon</>} />
+);


### PR DESCRIPTION
Closes #563

Wait until the underlying react PR https://github.com/patternfly/patternfly-react/pull/10016 is approved and merged before merging this codemod PR.

Possible improvements / thoughts:
- trying to adjust whatever consumer is passing to `labelIcon` to use the new FormGroupLabelHelp component is nearly impossible and there would be lots of edge cases, so I would rather not do that
- can we add a comment directly to the code, which would recommend using `FormGroupLabelHelp` component for the `labelHelp` prop? Something like: 
input:
```
<FormGroup labelIcon={<button>Help icon</button>} />
```

output:
```
<FormGroup labelHelp={/* CODEMODS RECOMMENDATION: use FormGroupLabelHelp component */ <button>Help icon</button>} />
```
or is a message in the codemod error sufficient?