### PR TITLE
chore(deps): upgrade TypeScript to latest version

### DIFF
--- a/packages/class-name-updater/CHANGELOG.md
+++ b/packages/class-name-updater/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/wise-king-sullyman/pf-codemods/compare/@patternfly/class-name-updater@1.3.1...@patternfly/class-name-updater@2.0.0) (2024-03-08)
+
+**Note:** Version bump only for package @patternfly/class-name-updater
+
+
+
+
+
 ## [1.3.1](https://github.com/patternfly/pf-codemods/compare/@patternfly/class-name-updater@1.3.0...@patternfly/class-name-updater@1.3.1) (2024-02-13)
 
 **Note:** Version bump only for package @patternfly/class-name-updater

--- a/packages/class-name-updater/package.json
+++ b/packages/class-name-updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/class-name-updater",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "description": "Utility to update class names with Patternfly version numbers",
   "author": "Red Hat",
   "license": "MIT",

--- a/packages/class-name-updater/package.json
+++ b/packages/class-name-updater/package.json
@@ -26,6 +26,6 @@
   },
   "devDependencies": {
     "@types/diff": "^5.0.9",
-    "typescript": "^5.3.3"
+    "typescript": "^5.4.2"
   }
 }

--- a/packages/pf-codemods/CHANGELOG.md
+++ b/packages/pf-codemods/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0](https://github.com/wise-king-sullyman/pf-codemods/compare/@patternfly/pf-codemods@1.83.10...@patternfly/pf-codemods@2.0.0) (2024-03-08)
+
+**Note:** Version bump only for package @patternfly/pf-codemods
+
+
+
+
+
 ## [1.83.10](https://github.com/patternfly/pf-codemods/compare/@patternfly/pf-codemods@1.83.9...@patternfly/pf-codemods@1.83.10) (2024-02-28)
 
 **Note:** Version bump only for package @patternfly/pf-codemods

--- a/packages/pf-codemods/package.json
+++ b/packages/pf-codemods/package.json
@@ -21,6 +21,6 @@
     "@typescript-eslint/parser": "^5.58.0",
     "commander": "^5.1.0",
     "eslint": "^7.3.0 || ^8.29.0",
-    "typescript": "^3.8.3"
+    "typescript": "^5.4.2"
   }
 }

--- a/packages/pf-codemods/package.json
+++ b/packages/pf-codemods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/pf-codemods",
-  "version": "1.83.10",
+  "version": "2.0.0",
   "description": "Codemods for v4 breaking change release 2020.07",
   "author": "Red Hat",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6735,15 +6735,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typescript@^5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
-  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
+typescript@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
+  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
 
 uglify-js@^3.1.4:
   version "3.9.4"


### PR DESCRIPTION
Upgrades TypeScript to the latest available version. This helps projects that are trying to apply the codemod on modern TypeScript code bases, as those will currently error out on unsupported syntax.