### PR TITLE
feat(EmptyState): support icons passed directly to EmptyStateHeader

### DIFF
--- a/packages/eslint-plugin-pf-codemods/src/rules/helpers/getFromPackage.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/helpers/getFromPackage.ts
@@ -5,6 +5,7 @@ import {
   Statement,
   Directive,
   ExportNamedDeclaration,
+  ImportDefaultSpecifier,
   ImportSpecifier,
   ExportSpecifier,
 } from "estree-jsx";
@@ -84,4 +85,24 @@ export function getFromPackage(
   );
 
   return { imports: specifiedImports, exports: specifiedExports };
+}
+
+export function getDefaultImportsFromPackage(
+  context: Rule.RuleContext,
+  packageName: string
+): ImportDefaultSpecifier[] {
+  const astBody = context.getSourceCode().ast.body;
+
+  const importDeclarations = astBody.filter(
+    (node) => node?.type === "ImportDeclaration"
+  ) as ImportDeclaration[];
+
+  const importDeclarationsFromPackage = filterByPackageName(
+    importDeclarations,
+    packageName
+  ) as ImportDeclaration[];
+
+  return importDeclarationsFromPackage
+    .filter((imp) => imp.specifiers[0]?.type === "ImportDefaultSpecifier")
+    .map((imp) => imp.specifiers[0]) as ImportDefaultSpecifier[];
 }

--- a/packages/eslint-plugin-pf-codemods/src/rules/helpers/pfPackageMatches.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/helpers/pfPackageMatches.ts
@@ -16,7 +16,9 @@ export function pfPackageMatches(
       parts[1] +
       "(/dist/(esm|js))?" +
       (parts[2] ? "/" + parts[2] : "") +
-      "(/(components|helpers)/.*)?$"
+      `(/(components|helpers${
+        parts[1] === "react-icons" ? "|icons" : ""
+      })/.*)?$`
   );
   return regex.test(nodeSrc);
 }

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/emptyStateHeaderMoveIntoEmptyState/emptyStateHeader-move-into-emptyState.test.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/emptyStateHeaderMoveIntoEmptyState/emptyStateHeader-move-into-emptyState.test.ts
@@ -378,5 +378,79 @@ ruleTester.run("emptyStateHeader-move-into-emptyState", rule, {
         },
       ],
     },
+    {
+      // with icon prop value not being wrapped in EmptyStateIcon (default import)
+      code: `import {
+        EmptyState,
+        EmptyStateHeader,
+      } from "@patternfly/react-core";
+
+      import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+      
+      export const EmptyStateHeaderMoveIntoEmptyStateInput = () => (
+        <EmptyState>
+          <EmptyStateHeader
+            icon={<CubesIcon />}
+            titleText="Empty state"
+          />
+        </EmptyState>
+      );
+      `,
+      output: `import {
+        EmptyState,
+        EmptyStateHeader,
+      } from "@patternfly/react-core";
+
+      import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+      
+      export const EmptyStateHeaderMoveIntoEmptyStateInput = () => (
+        <EmptyState   icon={CubesIcon}  titleText="Empty state">
+          </EmptyState>
+      );
+      `,
+      errors: [
+        {
+          message: `EmptyStateHeader has been moved inside of the EmptyState component and is now only customizable using props, and the EmptyStateIcon component now wraps content passed to the icon prop automatically. Additionally, the titleText prop is now required on EmptyState.`,
+          type: "JSXElement",
+        },
+      ],
+    },
+    {
+      // with icon prop value not being wrapped in EmptyStateIcon (classic import)
+      code: `import {
+        EmptyState,
+        EmptyStateHeader,
+      } from "@patternfly/react-core";
+
+      import { CubesIcon } from '@patternfly/react-icons';
+      
+      export const EmptyStateHeaderMoveIntoEmptyStateInput = () => (
+        <EmptyState>
+          <EmptyStateHeader
+            icon={<CubesIcon />}
+            titleText="Empty state"
+          />
+        </EmptyState>
+      );
+      `,
+      output: `import {
+        EmptyState,
+        EmptyStateHeader,
+      } from "@patternfly/react-core";
+
+      import { CubesIcon } from '@patternfly/react-icons';
+      
+      export const EmptyStateHeaderMoveIntoEmptyStateInput = () => (
+        <EmptyState   icon={CubesIcon}  titleText="Empty state">
+          </EmptyState>
+      );
+      `,
+      errors: [
+        {
+          message: `EmptyStateHeader has been moved inside of the EmptyState component and is now only customizable using props, and the EmptyStateIcon component now wraps content passed to the icon prop automatically. Additionally, the titleText prop is now required on EmptyState.`,
+          type: "JSXElement",
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/emptyStateHeaderMoveIntoEmptyState/emptyStateHeader-move-into-emptyState.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/emptyStateHeaderMoveIntoEmptyState/emptyStateHeader-move-into-emptyState.ts
@@ -157,13 +157,21 @@ module.exports = {
           });
         }
 
-        const icon = emptyStateIconComponentIconAttribute
-          ? context
+        const getIconPropText = () => {
+          if (emptyStateIconComponentIconAttribute) {
+            return context
               .getSourceCode()
-              .getText(emptyStateIconComponentIconAttribute)
-          : iconPropIsIconElement()
-          ? `icon={${iconElementIdentifier!.name}}`
-          : "";
+              .getText(emptyStateIconComponentIconAttribute);
+          }
+
+          if (iconPropIsIconElement()) {
+            return `icon={${iconElementIdentifier!.name}}`;
+          }
+
+          return "";
+        };
+
+        const icon = getIconPropText();
 
         context.report({
           node,

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/emptyStateHeaderMoveIntoEmptyState/emptyStateHeader-move-into-emptyState.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/emptyStateHeaderMoveIntoEmptyState/emptyStateHeader-move-into-emptyState.ts
@@ -110,8 +110,12 @@ module.exports = {
             (specifier) => specifier.imported.name === "EmptyStateIcon"
           );
 
+          if (!emptyStateIconImport) {
+            return false;
+          }
+
           return (
-            iconElementIdentifier?.name === emptyStateIconImport?.local.name
+            iconElementIdentifier?.name === emptyStateIconImport.local.name
           );
         };
 


### PR DESCRIPTION
Uses helpers from #602 which should be merged first before this PR.

Closes #595 