### PR TITLE
feat(UnavailableContent): update props to use bodyText

### DIFF
--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentBodyTextPropsUpdate/component-groups-unavailableContent-bodyText-props-update.md
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentBodyTextPropsUpdate/component-groups-unavailableContent-bodyText-props-update.md
@@ -1,0 +1,19 @@
+### component-groups-unavailableContent-bodyText-props-update [(react-component-groups/#244)](https://github.com/patternfly/react-component-groups/pull/244)
+
+In react-component-groups, we have replaced UnavailableContent's props `unavailableBodyPreStatusLinkText` and `unavailableBodyPostStatusLinkText` with one `bodyText` prop.
+Also status page link button has changed to a primary button. Consider capitalizing the `statusPageLinkText` prop.
+
+#### Examples
+
+In:
+
+```jsx
+%inputExample%
+```
+
+Out:
+
+```jsx
+%outputExample%
+```
+

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentBodyTextPropsUpdate/component-groups-unavailableContent-bodyText-props-update.test.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentBodyTextPropsUpdate/component-groups-unavailableContent-bodyText-props-update.test.ts
@@ -1,0 +1,140 @@
+const ruleTester = require("../../ruletester");
+import * as rule from "./component-groups-unavailableContent-bodyText-props-update";
+
+const renameMessage =
+  "In react-component-groups, we have replaced UnavailableContent's props `unavailableBodyPreStatusLinkText` and `unavailableBodyPostStatusLinkText` with one `bodyText` prop.";
+const statusPageMessage =
+  "In react-component-groups, UnavailableContent's status page link button has changed to a primary button. Consider capitalizing the `statusPageLinkText` prop.";
+
+const defaultPreStatusText =
+  "Try refreshing the page. If the problem persists, contact your organization administrator or visit our";
+const defaultPostStatusText = "for known outages.";
+const defaultStatusText = "status page";
+
+ruleTester.run("componentGroupsUnavailableContentBodyTextPropsUpdate", rule, {
+  valid: [
+    {
+      code: `<UnavailableContent unavailableBodyPreStatusLinkText="Visit our" statusPageLinkText="custom status page" unavailableBodyPostStatusLinkText="for more info." />`,
+    },
+    {
+      code: `import { UnavailableContent } from '@patternfly/react-component-groups'; <UnavailableContent someOtherProp />`,
+    },
+    // default import but folder not specified
+    {
+      code: `import UnavailableContent from '@patternfly/react-component-groups'; <UnavailableContent statusPageLinkText="custom status page" />`,
+    },
+  ],
+  invalid: [
+    // with both pre and post status link text, default statusPageLinkText
+    {
+      code: `import { UnavailableContent } from '@patternfly/react-component-groups';
+      <UnavailableContent 
+        unavailableBodyPreStatusLinkText="Visit our"
+        unavailableBodyPostStatusLinkText="for more info."
+      />`,
+      output: `import { UnavailableContent } from '@patternfly/react-component-groups';
+      <UnavailableContent 
+        bodyText="Visit our ${defaultStatusText} for more info."
+        
+      />`,
+      errors: [
+        {
+          message: renameMessage,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    // with only pre status link text, default statusPageLinkText
+    {
+      code: `import { UnavailableContent } from '@patternfly/react-component-groups';
+      <UnavailableContent unavailableBodyPreStatusLinkText="Visit our" />`,
+      output: `import { UnavailableContent } from '@patternfly/react-component-groups';
+      <UnavailableContent bodyText="Visit our ${defaultStatusText} ${defaultPostStatusText}" />`,
+      errors: [
+        {
+          message: renameMessage,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    // with only post status link text, default statusPageLinkText
+    {
+      code: `import { UnavailableContent } from '@patternfly/react-component-groups';
+      <UnavailableContent unavailableBodyPostStatusLinkText="for more info." />`,
+      output: `import { UnavailableContent } from '@patternfly/react-component-groups';
+      <UnavailableContent bodyText="${defaultPreStatusText} ${defaultStatusText} for more info." />`,
+      errors: [
+        {
+          message: renameMessage,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    // with custom statusPageLinkText
+    {
+      code: `import { UnavailableContent } from '@patternfly/react-component-groups';
+      <UnavailableContent statusPageLinkText="custom status page" />`,
+      output: `import { UnavailableContent } from '@patternfly/react-component-groups';
+      <UnavailableContent statusPageLinkText="Custom status page" />`,
+      errors: [
+        {
+          message: statusPageMessage,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    // with custom statusPageLinkText in a variable
+    {
+      code: `import { UnavailableContent } from '@patternfly/react-component-groups';
+      const statusPageLinkText = "custom status page";
+      <UnavailableContent statusPageLinkText={statusPageLinkText} />`,
+      output: `import { UnavailableContent } from '@patternfly/react-component-groups';
+      const statusPageLinkText = "custom status page";
+      <UnavailableContent statusPageLinkText="Custom status page" />`,
+      errors: [
+        {
+          message: statusPageMessage,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    // with both pre and post status link text, custom statusPageLinkText
+    {
+      code: `import { UnavailableContent } from '@patternfly/react-component-groups';
+      <UnavailableContent 
+        unavailableBodyPreStatusLinkText="Visit our"
+        unavailableBodyPostStatusLinkText="for more info."
+        statusPageLinkText="custom status page"
+      />`,
+      output: `import { UnavailableContent } from '@patternfly/react-component-groups';
+      <UnavailableContent 
+        bodyText="Visit our custom status page for more info."
+        
+        statusPageLinkText="Custom status page"
+      />`,
+      errors: [
+        {
+          message: statusPageMessage,
+          type: "JSXOpeningElement",
+        },
+        {
+          message: renameMessage,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+    // default import
+    {
+      code: `import UC from '@patternfly/react-component-groups/dist/dynamic/UnavailableContent';
+      <UC statusPageLinkText="custom status page" />`,
+      output: `import UC from '@patternfly/react-component-groups/dist/dynamic/UnavailableContent';
+      <UC statusPageLinkText="Custom status page" />`,
+      errors: [
+        {
+          message: statusPageMessage,
+          type: "JSXOpeningElement",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentBodyTextPropsUpdate/component-groups-unavailableContent-bodyText-props-update.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentBodyTextPropsUpdate/component-groups-unavailableContent-bodyText-props-update.ts
@@ -1,0 +1,99 @@
+import { Rule } from "eslint";
+import { JSXAttribute, JSXOpeningElement } from "estree-jsx";
+import {
+  getAllImportsFromPackage,
+  checkMatchingJSXOpeningElement,
+  getAttribute,
+  getAttributeValue,
+} from "../../helpers";
+
+// https://github.com/patternfly/react-component-groups/pull/244
+module.exports = {
+  meta: { fixable: "code" },
+  create: function (context: Rule.RuleContext) {
+    const basePackage = "@patternfly/react-component-groups";
+    const componentImports = getAllImportsFromPackage(context, basePackage, [
+      "UnavailableContent",
+    ]);
+
+    return !componentImports.length
+      ? {}
+      : {
+          JSXOpeningElement(node: JSXOpeningElement) {
+            if (!checkMatchingJSXOpeningElement(node, componentImports)) {
+              return;
+            }
+
+            const statusPageLinkTextProp = getAttribute(
+              node,
+              "statusPageLinkText"
+            );
+            const statusPageLinkTextString: string =
+              getAttributeValue(context, statusPageLinkTextProp?.value) ??
+              "status page";
+
+            if (statusPageLinkTextProp && statusPageLinkTextString.length) {
+              const firstChar = statusPageLinkTextString.charAt(0);
+
+              if (firstChar !== firstChar.toUpperCase()) {
+                context.report({
+                  node,
+                  message:
+                    "In react-component-groups, UnavailableContent's status page link button has changed to a primary button. Consider capitalizing the `statusPageLinkText` prop.",
+                  fix(fixer) {
+                    return fixer.replaceText(
+                      statusPageLinkTextProp.value!,
+                      `"${firstChar.toUpperCase()}${statusPageLinkTextString.slice(
+                        1
+                      )}"`
+                    );
+                  },
+                });
+              }
+            }
+
+            const preStatusLinkTextProp = getAttribute(
+              node,
+              "unavailableBodyPreStatusLinkText"
+            );
+            const postStatusLinkTextProp = getAttribute(
+              node,
+              "unavailableBodyPostStatusLinkText"
+            );
+
+            if (!preStatusLinkTextProp && !postStatusLinkTextProp) {
+              return;
+            }
+
+            const preStatusLinkTextString =
+              getAttributeValue(context, preStatusLinkTextProp?.value) ??
+              "Try refreshing the page. If the problem persists, contact your organization administrator or visit our";
+            const postStatusLinkTextString =
+              getAttributeValue(context, postStatusLinkTextProp?.value) ??
+              "for known outages.";
+
+            const bodyTextAttribute = `bodyText="${preStatusLinkTextString} ${statusPageLinkTextString} ${postStatusLinkTextString}"`;
+
+            context.report({
+              node,
+              message:
+                "In react-component-groups, we have replaced UnavailableContent's props `unavailableBodyPreStatusLinkText` and `unavailableBodyPostStatusLinkText` with one `bodyText` prop.",
+              fix(fixer) {
+                if (preStatusLinkTextProp && postStatusLinkTextProp) {
+                  return [
+                    fixer.replaceText(preStatusLinkTextProp, bodyTextAttribute),
+                    fixer.remove(postStatusLinkTextProp),
+                  ];
+                }
+
+                return fixer.replaceText(
+                  (preStatusLinkTextProp ||
+                    postStatusLinkTextProp) as JSXAttribute,
+                  bodyTextAttribute
+                );
+              },
+            });
+          },
+        };
+  },
+};

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentBodyTextPropsUpdate/componentGroupsUnavailableContentBodyTextPropsUpdateInput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentBodyTextPropsUpdate/componentGroupsUnavailableContentBodyTextPropsUpdateInput.tsx
@@ -1,0 +1,13 @@
+import { UnavailableContent } from "@patternfly/react-component-groups";
+
+export const ComponentGroupsUnavailableContentBodyTextPropsUpdateInput = () => (
+  <>
+    <UnavailableContent
+      unavailableBodyPreStatusLinkText="Visit our"
+      unavailableBodyPostStatusLinkText="for more info."
+      statusPageLinkText="custom status page"
+    />
+    <UnavailableContent unavailableBodyPreStatusLinkText="Visit our" />
+    <UnavailableContent unavailableBodyPostStatusLinkText="for more info." />
+  </>
+);

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentBodyTextPropsUpdate/componentGroupsUnavailableContentBodyTextPropsUpdateOutput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentBodyTextPropsUpdate/componentGroupsUnavailableContentBodyTextPropsUpdateOutput.tsx
@@ -1,0 +1,12 @@
+import { UnavailableContent } from "@patternfly/react-component-groups";
+
+export const ComponentGroupsUnavailableContentBodyTextPropsUpdateInput = () => (
+  <>
+    <UnavailableContent
+      bodyText="Visit our custom status page for more info."
+      statusPageLinkText="Custom status page"
+    />
+    <UnavailableContent bodyText="Visit our status page for known outages." />
+    <UnavailableContent bodyText="Try refreshing the page. If the problem persists, contact your organization administrator or visit our status page for more info." />
+  </>
+);

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentRenameProps/component-groups-unavailable-content-rename-props.md
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentRenameProps/component-groups-unavailable-content-rename-props.md
@@ -1,12 +1,6 @@
 ### component-groups-unavailable-content-rename-props [(react-component-groups/#145)](https://github.com/patternfly/react-component-groups/pull/145)
 
-The UnavailableContent component of React Component Groups has had the following props renamed:
-
-| Old prop name                       | New prop name      |
-| ----------------------------------- | ------------------ |
-| `unavailableTitleText`              | `titleText`        |
-| `unavailableBodyPreStatusLinkText`  | `preLinkBodyText`  |
-| `unavailableBodyPostStatusLinkText` | `postLinkBodyText` |
+The UnavailableContent component of React Component Groups has had the `unavailableTitleText` prop renamed to `titleText`.
 
 #### Examples
 

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentRenameProps/component-groups-unavailable-content-rename-props.test.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentRenameProps/component-groups-unavailable-content-rename-props.test.ts
@@ -1,18 +1,13 @@
 const ruleTester = require("../../ruletester");
 import * as rule from "./component-groups-unavailable-content-rename-props";
 
-const renames = [
-  { oldName: "unavailableTitleText", newName: "titleText" },
-  { oldName: "unavailableBodyPreStatusLinkText", newName: "preLinkBodyText" },
-  { oldName: "unavailableBodyPostStatusLinkText", newName: "postLinkBodyText" },
-];
-
-const errors = renames.map(
-  ({ oldName, newName }: { oldName: string; newName: string }) => ({
-    message: `The \`${oldName}\` prop for UnavailableContent has been renamed to \`${newName}\`.`,
+const errors = [
+  {
+    message:
+      "The unavailableTitleText prop for UnavailableContent has been renamed to titleText.",
     type: "JSXOpeningElement",
-  })
-);
+  },
+];
 
 ruleTester.run("component-groups-unavailable-content-rename-props", rule, {
   valid: [
@@ -25,33 +20,33 @@ ruleTester.run("component-groups-unavailable-content-rename-props", rule, {
   ],
   invalid: [
     {
-      code: `import { UnavailableContent } from '@patternfly/react-component-groups'; <UnavailableContent unavailableTitleText="foo" unavailableBodyPreStatusLinkText="bar" unavailableBodyPostStatusLinkText="bash" />`,
-      output: `import { UnavailableContent } from '@patternfly/react-component-groups'; <UnavailableContent titleText="foo" preLinkBodyText="bar" postLinkBodyText="bash" />`,
+      code: `import { UnavailableContent } from '@patternfly/react-component-groups'; <UnavailableContent unavailableTitleText="foo" />`,
+      output: `import { UnavailableContent } from '@patternfly/react-component-groups'; <UnavailableContent titleText="foo" />`,
       errors,
     },
     {
-      code: `import { UnavailableContent } from '@patternfly/react-component-groups'; const foo = "foo"; const bar = "bar"; const bash = "bash"; <UnavailableContent unavailableTitleText={foo} unavailableBodyPreStatusLinkText={bar} unavailableBodyPostStatusLinkText={bash} />`,
-      output: `import { UnavailableContent } from '@patternfly/react-component-groups'; const foo = "foo"; const bar = "bar"; const bash = "bash"; <UnavailableContent titleText={foo} preLinkBodyText={bar} postLinkBodyText={bash} />`,
+      code: `import { UnavailableContent } from '@patternfly/react-component-groups'; const foo = "foo"; <UnavailableContent unavailableTitleText={foo} />`,
+      output: `import { UnavailableContent } from '@patternfly/react-component-groups'; const foo = "foo"; <UnavailableContent titleText={foo} />`,
       errors,
     },
     {
-      code: `import { UnavailableContent } from '@patternfly/react-component-groups/dist/js/UnavailableContent'; <UnavailableContent unavailableTitleText="foo" unavailableBodyPreStatusLinkText="bar" unavailableBodyPostStatusLinkText="bash" />`,
-      output: `import { UnavailableContent } from '@patternfly/react-component-groups/dist/js/UnavailableContent'; <UnavailableContent titleText="foo" preLinkBodyText="bar" postLinkBodyText="bash" />`,
+      code: `import { UnavailableContent } from '@patternfly/react-component-groups/dist/js/UnavailableContent'; <UnavailableContent unavailableTitleText="foo" />`,
+      output: `import { UnavailableContent } from '@patternfly/react-component-groups/dist/js/UnavailableContent'; <UnavailableContent titleText="foo" />`,
       errors,
     },
     {
-      code: `import { UnavailableContent } from '@patternfly/react-component-groups/dist/esm/UnavailableContent'; <UnavailableContent unavailableTitleText="foo" unavailableBodyPreStatusLinkText="bar" unavailableBodyPostStatusLinkText="bash" />`,
-      output: `import { UnavailableContent } from '@patternfly/react-component-groups/dist/esm/UnavailableContent'; <UnavailableContent titleText="foo" preLinkBodyText="bar" postLinkBodyText="bash" />`,
+      code: `import { UnavailableContent } from '@patternfly/react-component-groups/dist/esm/UnavailableContent'; <UnavailableContent unavailableTitleText="foo" />`,
+      output: `import { UnavailableContent } from '@patternfly/react-component-groups/dist/esm/UnavailableContent'; <UnavailableContent titleText="foo" />`,
       errors,
     },
     {
-      code: `import { UnavailableContent } from '@patternfly/react-component-groups/dist/dynamic/UnavailableContent'; <UnavailableContent unavailableTitleText="foo" unavailableBodyPreStatusLinkText="bar" unavailableBodyPostStatusLinkText="bash" />`,
-      output: `import { UnavailableContent } from '@patternfly/react-component-groups/dist/dynamic/UnavailableContent'; <UnavailableContent titleText="foo" preLinkBodyText="bar" postLinkBodyText="bash" />`,
+      code: `import { UnavailableContent } from '@patternfly/react-component-groups/dist/dynamic/UnavailableContent'; <UnavailableContent unavailableTitleText="foo" />`,
+      output: `import { UnavailableContent } from '@patternfly/react-component-groups/dist/dynamic/UnavailableContent'; <UnavailableContent titleText="foo" />`,
       errors,
     },
     {
-      code: `import UC from '@patternfly/react-component-groups/dist/dynamic/UnavailableContent'; <UC unavailableTitleText="foo" unavailableBodyPreStatusLinkText="bar" unavailableBodyPostStatusLinkText="bash" />`,
-      output: `import UC from '@patternfly/react-component-groups/dist/dynamic/UnavailableContent'; <UC titleText="foo" preLinkBodyText="bar" postLinkBodyText="bash" />`,
+      code: `import UC from '@patternfly/react-component-groups/dist/dynamic/UnavailableContent'; <UC unavailableTitleText="foo" />`,
+      output: `import UC from '@patternfly/react-component-groups/dist/dynamic/UnavailableContent'; <UC titleText="foo" />`,
       errors,
     },
   ],

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentRenameProps/component-groups-unavailable-content-rename-props.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentRenameProps/component-groups-unavailable-content-rename-props.ts
@@ -3,28 +3,12 @@ import { Renames } from "../../helpers/renameSinglePropOnNode";
 
 // https://github.com/patternfly/react-component-groups/pull/145
 
-const formatMessage = (oldPropName: string, newPropName: string) =>
-  `The \`${oldPropName}\` prop for UnavailableContent has been renamed to \`${newPropName}\`.`;
-
 const renames: Renames = {
   UnavailableContent: {
     unavailableTitleText: {
       newName: "titleText",
-      message: formatMessage("unavailableTitleText", "titleText"),
-    },
-    unavailableBodyPreStatusLinkText: {
-      newName: "preLinkBodyText",
-      message: formatMessage(
-        "unavailableBodyPreStatusLinkText",
-        "preLinkBodyText"
-      ),
-    },
-    unavailableBodyPostStatusLinkText: {
-      newName: "postLinkBodyText",
-      message: formatMessage(
-        "unavailableBodyPostStatusLinkText",
-        "postLinkBodyText"
-      ),
+      message:
+        "The unavailableTitleText prop for UnavailableContent has been renamed to titleText.",
     },
   },
 };

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentRenameProps/componentGroupsUnavailableContentRenamePropsInput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentRenameProps/componentGroupsUnavailableContentRenamePropsInput.tsx
@@ -1,9 +1,5 @@
 import { UnavailableContent } from "@patternfly/react-component-groups";
 
 export const ComponentGroupsUnavailableContentRenamePropsInput = () => (
-  <UnavailableContent
-    unavailableTitleText="foo"
-    unavailableBodyPreStatusLinkText="bar"
-    unavailableBodyPostStatusLinkText="bash"
-  />
+  <UnavailableContent unavailableTitleText="foo" />
 );

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentRenameProps/componentGroupsUnavailableContentRenamePropsOutput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsUnavailableContentRenameProps/componentGroupsUnavailableContentRenamePropsOutput.tsx
@@ -1,9 +1,5 @@
 import { UnavailableContent } from "@patternfly/react-component-groups";
 
 export const ComponentGroupsUnavailableContentRenamePropsInput = () => (
-  <UnavailableContent
-    titleText="foo"
-    preLinkBodyText="bar"
-    postLinkBodyText="bash"
-  />
+  <UnavailableContent titleText="foo" />
 );


### PR DESCRIPTION
Closes #732 

- because `unavailableBodyPreStatusLinkText` and `unavailableBodyPostStatusLinkText` has already been renamed to `preLinkBodyText` and `postLinkBodyText` and are being renamed again and merged to only one `bodyText` prop, I also modified the `component-groups-unavailable-content-rename-props` rule to only rename `unavailableTitleText`
- `statusPageLinkText` prop is now being used for a **primary** button instead of a link button -> the text should be capitalized (as it is being done with the default "status page" -> "Status page")