### PR TITLE
fix(Pagination): Fix rule to report as a warning instead of an error

### DIFF
--- a/packages/eslint-plugin-pf-codemods/src/ruleCustomization.ts
+++ b/packages/eslint-plugin-pf-codemods/src/ruleCustomization.ts
@@ -34,7 +34,7 @@ export const warningRules = [
   "page-warn-updated-markup",
   "pageBreadcrumbAndSection-warn-updated-wrapperLogic",
   "pageSection-warn-variantClasses-applied",
-  "pagination-warn-markup-changed.test",
+  "pagination-warn-markup-changed",
   "popover-warn-appendTo-default",
   "popper-update-appendTo-default",
   "react-dropzone-warn-upgrade",


### PR DESCRIPTION
Looks like we typo'd a warning rule