### PR TITLE
fix(Text): Replace missed text variant enums with content variant enum

### DIFF
--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/textReplaceWithContent/text-replace-with-content.test.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/textReplaceWithContent/text-replace-with-content.test.ts
@@ -142,6 +142,16 @@ ruleTester.run("text-replace-with-content", rule, {
       errors: [importDeclarationError, identifierError],
     },
     {
+      code: `import { TextListVariants } from '@patternfly/react-core'; const foo = TextListVariants.ul`,
+      output: `import { ContentVariants } from '@patternfly/react-core'; const foo = ContentVariants.ul`,
+      errors: [importDeclarationError, identifierError],
+    },
+    {
+      code: `import { TextListItemVariants } from '@patternfly/react-core'; const foo = TextListItemVariants.li`,
+      output: `import { ContentVariants } from '@patternfly/react-core'; const foo = ContentVariants.li`,
+      errors: [importDeclarationError, identifierError],
+    },
+    {
       code: `import { TextProps } from '@patternfly/react-core'; interface Foo extends TextProps {}`,
       output: `import { ContentProps } from '@patternfly/react-core'; interface Foo extends ContentProps {}`,
       errors: [importDeclarationError, identifierError],

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/textReplaceWithContent/text-replace-with-content.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/textReplaceWithContent/text-replace-with-content.ts
@@ -14,6 +14,7 @@ import {
 } from "../../helpers";
 
 // https://github.com/patternfly/patternfly-react/pull/10643
+
 module.exports = {
   meta: { fixable: "code" },
   create: function (context: Rule.RuleContext) {
@@ -21,7 +22,12 @@ module.exports = {
 
     const textComponents = ["Text", "TextContent", "TextList", "TextListItem"];
 
-    const nonComponentTextIdentifiers = ["TextProps", "TextVariants"];
+    const nonComponentTextIdentifiers = [
+      "TextProps",
+      "TextVariants",
+      "TextListVariants",
+      "TextListItemVariants",
+    ];
 
     const allTextIdentifiers = [
       ...textComponents,
@@ -34,6 +40,18 @@ module.exports = {
 
     const errorMessage =
       "We have replaced Text, TextContent, TextList and TextListItem with one Content component. Running this fix will change all of those components names to Content and add a `component` prop where necessary.";
+
+    function getNewText(specifier: string) {
+      if (textComponents.includes(specifier)) {
+        return "Content";
+      }
+
+      if (specifier === "TextProps") {
+        return "ContentProps";
+      }
+
+      return "ContentVariants";
+    }
 
     return !textImports.length
       ? {}
@@ -51,11 +69,7 @@ module.exports = {
               }
 
               const specifierName = specifierToReplace.imported.name;
-              const newText = nonComponentTextIdentifiers.includes(
-                specifierName
-              )
-                ? specifierName.replace("Text", "Content")
-                : "Content";
+              const newText = getNewText(specifierName);
 
               context.report({
                 node,
@@ -173,7 +187,7 @@ module.exports = {
               return;
             }
 
-            const newText = node.name.replace("Text", "Content");
+            const newText = getNewText(node.name);
 
             context.report({
               node,

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/textReplaceWithContent/textReplaceWithContentInput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/textReplaceWithContent/textReplaceWithContentInput.tsx
@@ -2,13 +2,18 @@ import {
   Text,
   TextContent,
   TextList,
+  TextListVariants,
   TextListItem,
+  TextListItemVariants,
   TextProps,
   TextVariants,
 } from "@patternfly/react-core";
 
 export const TextReplaceWithContentInput = () => {
   interface Foo extends TextProps {}
+  const foo = TextVariants.h1;
+  const bar = TextListVariants.ul;
+  const baz = TextListItemVariants.li;
 
   return (
     <>

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/textReplaceWithContent/textReplaceWithContentOutput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/textReplaceWithContent/textReplaceWithContentOutput.tsx
@@ -2,13 +2,18 @@ import {
   Content,
   Content,
   Content,
+  ContentVariants,
   Content,
+  ContentVariants,
   ContentProps,
   ContentVariants,
 } from "@patternfly/react-core";
 
 export const TextReplaceWithContentInput = () => {
   interface Foo extends ContentProps {}
+  const foo = ContentVariants.h1;
+  const bar = ContentVariants.ul;
+  const baz = ContentVariants.li;
 
   return (
     <>


### PR DESCRIPTION
Not sure if it will close it, but at least towards #749