### PR TITLE
feat(component groups): rename various components

### DIFF
--- a/packages/eslint-plugin-pf-codemods/src/rules/helpers/renameComponent.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/helpers/renameComponent.ts
@@ -49,7 +49,17 @@ function getFixes(
     );
   }
 
-  const shouldRenameNode =
+  let shouldRenameNode = false;
+
+  if (
+    nodeImport.type === "ImportDefaultSpecifier" &&
+    nodeImport.local.name === oldName
+  ) {
+    shouldRenameNode = true;
+    fixes.push(fixer.replaceText(nodeImport, newName));
+  }
+
+  shouldRenameNode ||=
     isNamedImport && nodeImport.imported.name === nodeImport.local.name;
 
   if (shouldRenameNode) {

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsContentHeaderRenameToPageHeader/component-groups-contentHeader-rename-to-pageHeader.md
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsContentHeaderRenameToPageHeader/component-groups-contentHeader-rename-to-pageHeader.md
@@ -1,0 +1,18 @@
+### component-groups-contentHeader-rename-to-pageHeader [(react-component-groups/#313)](https://github.com/patternfly/react-component-groups/pull/313)
+
+In react-component-groups, we've renamed ContentHeader component to PageHeader
+
+#### Examples
+
+In:
+
+```jsx
+%inputExample%
+```
+
+Out:
+
+```jsx
+%outputExample%
+```
+

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsContentHeaderRenameToPageHeader/component-groups-contentHeader-rename-to-pageHeader.test.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsContentHeaderRenameToPageHeader/component-groups-contentHeader-rename-to-pageHeader.test.ts
@@ -1,0 +1,57 @@
+const ruleTester = require("../../ruletester");
+import * as rule from "./component-groups-contentHeader-rename-to-pageHeader";
+
+const errors = [
+  {
+    message: `ContentHeader has been renamed to PageHeader.`,
+    type: "JSXOpeningElement",
+  },
+];
+
+ruleTester.run("component-groups-contentHeader-rename-to-pageHeader", rule, {
+  valid: [
+    // missing import
+    {
+      code: `<ContentHeader />`,
+    },
+    // import from wrong package
+    {
+      code: `import { ContentHeader } from '@patternfly/react-core'; <ContentHeader />`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import { ContentHeader } from '@patternfly/react-component-groups'; <ContentHeader />`,
+      output: `import { PageHeader } from '@patternfly/react-component-groups'; <PageHeader data-codemods />`,
+      errors,
+    },
+    // named import with alias
+    {
+      code: `import { ContentHeader as Header } from '@patternfly/react-component-groups'; <Header />`,
+      output: `import { PageHeader as Header } from '@patternfly/react-component-groups'; <Header />`,
+      errors,
+    },
+    // default imports
+    {
+      code: `import ContentHeader from '@patternfly/react-component-groups/dist/cjs/ContentHeader/index'; <ContentHeader />`,
+      output: `import PageHeader from '@patternfly/react-component-groups/dist/cjs/PageHeader/index'; <PageHeader data-codemods />`,
+      errors,
+    },
+    {
+      code: `import ContentHeader from '@patternfly/react-component-groups/dist/esm/ContentHeader/index'; <ContentHeader />`,
+      output: `import PageHeader from '@patternfly/react-component-groups/dist/esm/PageHeader/index'; <PageHeader data-codemods />`,
+      errors,
+    },
+    {
+      code: `import ContentHeader from '@patternfly/react-component-groups/dist/dynamic/ContentHeader'; <ContentHeader />`,
+      output: `import PageHeader from '@patternfly/react-component-groups/dist/dynamic/PageHeader'; <PageHeader data-codemods />`,
+      errors,
+    },
+    // default import with name not matching the component name
+    {
+      code: `import Header from '@patternfly/react-component-groups/dist/dynamic/ContentHeader'; <Header />`,
+      output: `import Header from '@patternfly/react-component-groups/dist/dynamic/PageHeader'; <Header />`,
+      errors,
+    },
+  ],
+});

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsContentHeaderRenameToPageHeader/component-groups-contentHeader-rename-to-pageHeader.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsContentHeaderRenameToPageHeader/component-groups-contentHeader-rename-to-pageHeader.ts
@@ -1,0 +1,12 @@
+import { renameComponent } from "../../helpers/renameComponent";
+
+// https://github.com/patternfly/react-component-groups/pull/313
+module.exports = {
+  meta: { fixable: "code" },
+  create: renameComponent(
+    {
+      ContentHeader: "PageHeader",
+    },
+    "@patternfly/react-component-groups"
+  ),
+};

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsContentHeaderRenameToPageHeader/componentGroupsContentHeaderRenameToPageHeaderInput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsContentHeaderRenameToPageHeader/componentGroupsContentHeaderRenameToPageHeaderInput.tsx
@@ -1,0 +1,5 @@
+import { ContentHeader } from "@patternfly/react-component-groups";
+
+export const ComponentGroupsContentHeaderRenameToPageHeaderInput = () => (
+  <ContentHeader />
+);

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsContentHeaderRenameToPageHeader/componentGroupsContentHeaderRenameToPageHeaderOutput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsContentHeaderRenameToPageHeader/componentGroupsContentHeaderRenameToPageHeaderOutput.tsx
@@ -1,0 +1,5 @@
+import { PageHeader } from "@patternfly/react-component-groups";
+
+export const ComponentGroupsContentHeaderRenameToPageHeaderInput = () => (
+  <PageHeader data-codemods />
+);

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectRenameProps/component-groups-invalidObject-rename-props.test.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectRenameProps/component-groups-invalidObject-rename-props.test.ts
@@ -6,88 +6,99 @@ const renameMap = {
   invalidObjectBodyText: "bodyText",
 };
 
-const errors = Object.entries(renameMap).map(([oldName, newName]) => ({
-  message: `The ${oldName} prop for InvalidObject has been renamed to ${newName}.`,
-  type: "JSXOpeningElement",
-}));
+const getErrors = (component: string) =>
+  Object.entries(renameMap).map(([oldName, newName]) => ({
+    message: `The ${oldName} prop for ${component} has been renamed to ${newName}.`,
+    type: "JSXOpeningElement",
+  }));
+
+const components = ["InvalidObject", "MissingPage"];
+
+const valid = components
+  .map((component) => [
+    {
+      code: `<${component} invalidObjectTitleText="" />`,
+    },
+    {
+      code: `<${component} invalidObjectBodyText="" />`,
+    },
+    {
+      code: `import { ${component} } from '@patternfly/react-component-groups'; <${component} someOtherProp />`,
+    },
+  ])
+  .flat();
+
+const invalid = components
+  .map((component) => [
+    {
+      code: `import { ${component} } from '@patternfly/react-component-groups';
+    <${component}
+      invalidObjectTitleText="Sample title text"
+      invalidObjectBodyText="Sample body text"
+    />`,
+      output: `import { ${component} } from '@patternfly/react-component-groups';
+    <${component}
+      titleText="Sample title text"
+      bodyText="Sample body text"
+    />`,
+      errors: getErrors(component),
+    },
+    {
+      code: `import ${component} from '@patternfly/react-component-groups/dist/cjs/${component}/index';
+    <${component}
+      invalidObjectTitleText="Sample title text"
+      invalidObjectBodyText="Sample body text"
+    />`,
+      output: `import ${component} from '@patternfly/react-component-groups/dist/cjs/${component}/index';
+    <${component}
+      titleText="Sample title text"
+      bodyText="Sample body text"
+    />`,
+      errors: getErrors(component),
+    },
+    {
+      code: `import ${component} from '@patternfly/react-component-groups/dist/esm/${component}/index';
+    <${component}
+      invalidObjectTitleText="Sample title text"
+      invalidObjectBodyText="Sample body text"
+    />`,
+      output: `import ${component} from '@patternfly/react-component-groups/dist/esm/${component}/index';
+    <${component}
+      titleText="Sample title text"
+      bodyText="Sample body text"
+    />`,
+      errors: getErrors(component),
+    },
+    {
+      code: `import ${component} from '@patternfly/react-component-groups/dist/dynamic/${component}';
+    <${component}
+      invalidObjectTitleText="Sample title text"
+      invalidObjectBodyText="Sample body text"
+    />`,
+      output: `import ${component} from '@patternfly/react-component-groups/dist/dynamic/${component}';
+    <${component}
+      titleText="Sample title text"
+      bodyText="Sample body text"
+    />`,
+      errors: getErrors(component),
+    },
+    {
+      code: `import InvObj from '@patternfly/react-component-groups/dist/dynamic/${component}';
+    <InvObj
+      invalidObjectTitleText="Sample title text"
+      invalidObjectBodyText="Sample body text"
+    />`,
+      output: `import InvObj from '@patternfly/react-component-groups/dist/dynamic/${component}';
+    <InvObj
+      titleText="Sample title text"
+      bodyText="Sample body text"
+    />`,
+      errors: getErrors(component),
+    },
+  ])
+  .flat();
 
 ruleTester.run("component-groups-invalidObject-rename-props", rule, {
-  valid: [
-    {
-      code: `<InvalidObject invalidObjectTitleText="" />`,
-    },
-    {
-      code: `<InvalidObject invalidObjectBodyText="" />`,
-    },
-    {
-      code: `import { InvalidObject } from '@patternfly/react-component-groups'; <InvalidObject someOtherProp />`,
-    },
-  ],
-  invalid: [
-    {
-      code: `import { InvalidObject } from '@patternfly/react-component-groups';
-      <InvalidObject
-        invalidObjectTitleText="Sample title text"
-        invalidObjectBodyText="Sample body text"
-      />`,
-      output: `import { InvalidObject } from '@patternfly/react-component-groups';
-      <InvalidObject
-        titleText="Sample title text"
-        bodyText="Sample body text"
-      />`,
-      errors,
-    },
-    {
-      code: `import InvalidObject from '@patternfly/react-component-groups/dist/cjs/InvalidObject/index';
-      <InvalidObject
-        invalidObjectTitleText="Sample title text"
-        invalidObjectBodyText="Sample body text"
-      />`,
-      output: `import InvalidObject from '@patternfly/react-component-groups/dist/cjs/InvalidObject/index';
-      <InvalidObject
-        titleText="Sample title text"
-        bodyText="Sample body text"
-      />`,
-      errors,
-    },
-    {
-      code: `import InvalidObject from '@patternfly/react-component-groups/dist/esm/InvalidObject/index';
-      <InvalidObject
-        invalidObjectTitleText="Sample title text"
-        invalidObjectBodyText="Sample body text"
-      />`,
-      output: `import InvalidObject from '@patternfly/react-component-groups/dist/esm/InvalidObject/index';
-      <InvalidObject
-        titleText="Sample title text"
-        bodyText="Sample body text"
-      />`,
-      errors,
-    },
-    {
-      code: `import InvalidObject from '@patternfly/react-component-groups/dist/dynamic/InvalidObject';
-      <InvalidObject
-        invalidObjectTitleText="Sample title text"
-        invalidObjectBodyText="Sample body text"
-      />`,
-      output: `import InvalidObject from '@patternfly/react-component-groups/dist/dynamic/InvalidObject';
-      <InvalidObject
-        titleText="Sample title text"
-        bodyText="Sample body text"
-      />`,
-      errors,
-    },
-    {
-      code: `import InvObj from '@patternfly/react-component-groups/dist/dynamic/InvalidObject';
-      <InvObj
-        invalidObjectTitleText="Sample title text"
-        invalidObjectBodyText="Sample body text"
-      />`,
-      output: `import InvObj from '@patternfly/react-component-groups/dist/dynamic/InvalidObject';
-      <InvObj
-        titleText="Sample title text"
-        bodyText="Sample body text"
-      />`,
-      errors,
-    },
-  ],
+  valid,
+  invalid,
 });

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectRenameProps/component-groups-invalidObject-rename-props.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectRenameProps/component-groups-invalidObject-rename-props.ts
@@ -3,20 +3,27 @@ import { Renames } from "../../helpers/renameSinglePropOnNode";
 
 // https://github.com/patternfly/react-component-groups/pull/145
 
-const formatMessage = (oldPropName: string, newPropName: string) =>
-  `The ${oldPropName} prop for InvalidObject has been renamed to ${newPropName}.`;
+const formatMessage = (
+  component: string,
+  oldPropName: string,
+  newPropName: string
+) =>
+  `The ${oldPropName} prop for ${component} has been renamed to ${newPropName}.`;
+
+const getPropsRenames = (component: string) => ({
+  invalidObjectTitleText: {
+    newName: "titleText",
+    message: formatMessage(component, "invalidObjectTitleText", "titleText"),
+  },
+  invalidObjectBodyText: {
+    newName: "bodyText",
+    message: formatMessage(component, "invalidObjectBodyText", "bodyText"),
+  },
+});
 
 const renames: Renames = {
-  InvalidObject: {
-    invalidObjectTitleText: {
-      newName: "titleText",
-      message: formatMessage("invalidObjectTitleText", "titleText"),
-    },
-    invalidObjectBodyText: {
-      newName: "bodyText",
-      message: formatMessage("invalidObjectBodyText", "bodyText"),
-    },
-  },
+  InvalidObject: getPropsRenames("InvalidObject"),
+  MissingPage: getPropsRenames("MissingPage"),
 };
 
 module.exports = {

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectRenameToMissingPage/component-groups-invalidObject-rename-to-missingPage.md
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectRenameToMissingPage/component-groups-invalidObject-rename-to-missingPage.md
@@ -1,0 +1,18 @@
+### component-groups-invalidObject-rename-to-missingPage [(react-component-groups/#313)](https://github.com/patternfly/react-component-groups/pull/313)
+
+In react-component-groups, we've renamed InvalidObject component to MissingPage
+
+#### Examples
+
+In:
+
+```jsx
+%inputExample%
+```
+
+Out:
+
+```jsx
+%outputExample%
+```
+

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectRenameToMissingPage/component-groups-invalidObject-rename-to-missingPage.test.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectRenameToMissingPage/component-groups-invalidObject-rename-to-missingPage.test.ts
@@ -1,0 +1,57 @@
+const ruleTester = require("../../ruletester");
+import * as rule from "./component-groups-invalidObject-rename-to-missingPage";
+
+const errors = [
+  {
+    message: `InvalidObject has been renamed to MissingPage.`,
+    type: "JSXOpeningElement",
+  },
+];
+
+ruleTester.run("component-groups-invalidObject-rename-to-missingPage", rule, {
+  valid: [
+    // missing import
+    {
+      code: `<InvalidObject />`,
+    },
+    // import from wrong package
+    {
+      code: `import { InvalidObject } from '@patternfly/react-core'; <InvalidObject />`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import { InvalidObject } from '@patternfly/react-component-groups'; <InvalidObject />`,
+      output: `import { MissingPage } from '@patternfly/react-component-groups'; <MissingPage data-codemods />`,
+      errors,
+    },
+    // named import with alias
+    {
+      code: `import { InvalidObject as InvObj } from '@patternfly/react-component-groups'; <InvObj />`,
+      output: `import { MissingPage as InvObj } from '@patternfly/react-component-groups'; <InvObj />`,
+      errors,
+    },
+    // default imports
+    {
+      code: `import InvalidObject from '@patternfly/react-component-groups/dist/cjs/InvalidObject/index'; <InvalidObject />`,
+      output: `import MissingPage from '@patternfly/react-component-groups/dist/cjs/MissingPage/index'; <MissingPage data-codemods />`,
+      errors,
+    },
+    {
+      code: `import InvalidObject from '@patternfly/react-component-groups/dist/esm/InvalidObject/index'; <InvalidObject />`,
+      output: `import MissingPage from '@patternfly/react-component-groups/dist/esm/MissingPage/index'; <MissingPage data-codemods />`,
+      errors,
+    },
+    {
+      code: `import InvalidObject from '@patternfly/react-component-groups/dist/dynamic/InvalidObject'; <InvalidObject />`,
+      output: `import MissingPage from '@patternfly/react-component-groups/dist/dynamic/MissingPage'; <MissingPage data-codemods />`,
+      errors,
+    },
+    // default import with name not matching the component name
+    {
+      code: `import InvObj from '@patternfly/react-component-groups/dist/dynamic/InvalidObject'; <InvObj />`,
+      output: `import InvObj from '@patternfly/react-component-groups/dist/dynamic/MissingPage'; <InvObj />`,
+      errors,
+    },
+  ],
+});

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectRenameToMissingPage/component-groups-invalidObject-rename-to-missingPage.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectRenameToMissingPage/component-groups-invalidObject-rename-to-missingPage.ts
@@ -1,0 +1,12 @@
+import { renameComponent } from "../../helpers/renameComponent";
+
+// https://github.com/patternfly/react-component-groups/pull/313
+module.exports = {
+  meta: { fixable: "code" },
+  create: renameComponent(
+    {
+      InvalidObject: "MissingPage",
+    },
+    "@patternfly/react-component-groups"
+  ),
+};

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectRenameToMissingPage/componentGroupsInvalidObjectRenameToMissingPageInput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectRenameToMissingPage/componentGroupsInvalidObjectRenameToMissingPageInput.tsx
@@ -1,0 +1,4 @@
+import { InvalidObject } from "@patternfly/react-component-groups";
+
+export const ComponentGroupsInvalidObjectRenameToMissingPageInput =
+  () => <InvalidObject />;

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectRenameToMissingPage/componentGroupsInvalidObjectRenameToMissingPageOutput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectRenameToMissingPage/componentGroupsInvalidObjectRenameToMissingPageOutput.tsx
@@ -1,0 +1,4 @@
+import { MissingPage } from "@patternfly/react-component-groups";
+
+export const ComponentGroupsInvalidObjectRenameToMissingPageInput =
+  () => <MissingPage data-codemods />;

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsNotAuthorizedRenameProps/component-groups-notAuthorized-rename-props.test.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsNotAuthorizedRenameProps/component-groups-notAuthorized-rename-props.test.ts
@@ -6,88 +6,99 @@ const renameMap = {
   title: "titleText",
 };
 
-const errors = Object.entries(renameMap).map(([oldName, newName]) => ({
-  message: `The ${oldName} prop for NotAuthorized has been renamed to ${newName}.`,
-  type: "JSXOpeningElement",
-}));
+const getErrors = (component: string) =>
+  Object.entries(renameMap).map(([oldName, newName]) => ({
+    message: `The ${oldName} prop for ${component} has been renamed to ${newName}.`,
+    type: "JSXOpeningElement",
+  }));
+
+const components = ["NotAuthorized", "UnauthorizedAccess"];
+
+const valid = components
+  .map((component) => [
+    {
+      code: `<${component} description="" />`,
+    },
+    {
+      code: `<${component} title="" />`,
+    },
+    {
+      code: `import { ${component} } from '@patternfly/react-component-groups'; <${component} someOtherProp />`,
+    },
+  ])
+  .flat();
+
+const invalid = components
+  .map((component) => [
+    {
+      code: `import { ${component} } from '@patternfly/react-component-groups';
+    <${component}
+      description="Description text" 
+      title="Title text"
+    />`,
+      output: `import { ${component} } from '@patternfly/react-component-groups';
+    <${component}
+      bodyText="Description text" 
+      titleText="Title text"
+    />`,
+      errors: getErrors(component),
+    },
+    {
+      code: `import ${component} from '@patternfly/react-component-groups/dist/cjs/${component}/index';
+    <${component}
+      description="Description text" 
+      title="Title text"
+    />`,
+      output: `import ${component} from '@patternfly/react-component-groups/dist/cjs/${component}/index';
+    <${component}
+      bodyText="Description text" 
+      titleText="Title text"
+    />`,
+      errors: getErrors(component),
+    },
+    {
+      code: `import ${component} from '@patternfly/react-component-groups/dist/esm/${component}/index';
+    <${component}
+      description="Description text" 
+      title="Title text"
+    />`,
+      output: `import ${component} from '@patternfly/react-component-groups/dist/esm/${component}/index';
+    <${component}
+      bodyText="Description text" 
+      titleText="Title text"
+    />`,
+      errors: getErrors(component),
+    },
+    {
+      code: `import ${component} from '@patternfly/react-component-groups/dist/dynamic/${component}';
+    <${component}
+      description="Description text" 
+      title="Title text"
+    />`,
+      output: `import ${component} from '@patternfly/react-component-groups/dist/dynamic/${component}';
+    <${component}
+      bodyText="Description text" 
+      titleText="Title text"
+    />`,
+      errors: getErrors(component),
+    },
+    {
+      code: `import NotAuth from '@patternfly/react-component-groups/dist/dynamic/${component}';
+    <NotAuth
+      description="Description text" 
+      title="Title text"
+    />`,
+      output: `import NotAuth from '@patternfly/react-component-groups/dist/dynamic/${component}';
+    <NotAuth
+      bodyText="Description text" 
+      titleText="Title text"
+    />`,
+      errors: getErrors(component),
+    },
+  ])
+  .flat();
 
 ruleTester.run("component-groups-notAuthorized-rename-props", rule, {
-  valid: [
-    {
-      code: `<NotAuthorized description="" />`,
-    },
-    {
-      code: `<NotAuthorized title="" />`,
-    },
-    {
-      code: `import { NotAuthorized } from '@patternfly/react-component-groups'; <NotAuthorized someOtherProp />`,
-    },
-  ],
-  invalid: [
-    {
-      code: `import { NotAuthorized } from '@patternfly/react-component-groups';
-      <NotAuthorized
-        description="Description text" 
-        title="Title text"
-      />`,
-      output: `import { NotAuthorized } from '@patternfly/react-component-groups';
-      <NotAuthorized
-        bodyText="Description text" 
-        titleText="Title text"
-      />`,
-      errors,
-    },
-    {
-      code: `import NotAuthorized from '@patternfly/react-component-groups/dist/cjs/NotAuthorized/index';
-      <NotAuthorized
-        description="Description text" 
-        title="Title text"
-      />`,
-      output: `import NotAuthorized from '@patternfly/react-component-groups/dist/cjs/NotAuthorized/index';
-      <NotAuthorized
-        bodyText="Description text" 
-        titleText="Title text"
-      />`,
-      errors,
-    },
-    {
-      code: `import NotAuthorized from '@patternfly/react-component-groups/dist/esm/NotAuthorized/index';
-      <NotAuthorized
-        description="Description text" 
-        title="Title text"
-      />`,
-      output: `import NotAuthorized from '@patternfly/react-component-groups/dist/esm/NotAuthorized/index';
-      <NotAuthorized
-        bodyText="Description text" 
-        titleText="Title text"
-      />`,
-      errors,
-    },
-    {
-      code: `import NotAuthorized from '@patternfly/react-component-groups/dist/dynamic/NotAuthorized';
-      <NotAuthorized
-        description="Description text" 
-        title="Title text"
-      />`,
-      output: `import NotAuthorized from '@patternfly/react-component-groups/dist/dynamic/NotAuthorized';
-      <NotAuthorized
-        bodyText="Description text" 
-        titleText="Title text"
-      />`,
-      errors,
-    },
-    {
-      code: `import NotAuth from '@patternfly/react-component-groups/dist/dynamic/NotAuthorized';
-      <NotAuth
-        description="Description text" 
-        title="Title text"
-      />`,
-      output: `import NotAuth from '@patternfly/react-component-groups/dist/dynamic/NotAuthorized';
-      <NotAuth
-        bodyText="Description text" 
-        titleText="Title text"
-      />`,
-      errors,
-    },
-  ],
+  valid,
+  invalid,
 });

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsNotAuthorizedRenameProps/component-groups-notAuthorized-rename-props.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsNotAuthorizedRenameProps/component-groups-notAuthorized-rename-props.ts
@@ -3,20 +3,27 @@ import { Renames } from "../../helpers/renameSinglePropOnNode";
 
 // https://github.com/patternfly/react-component-groups/pull/145
 
-const formatMessage = (oldPropName: string, newPropName: string) =>
-  `The ${oldPropName} prop for NotAuthorized has been renamed to ${newPropName}.`;
+const formatMessage = (
+  component: string,
+  oldPropName: string,
+  newPropName: string
+) =>
+  `The ${oldPropName} prop for ${component} has been renamed to ${newPropName}.`;
+
+const getPropsRenames = (component: string) => ({
+  description: {
+    newName: "bodyText",
+    message: formatMessage(component, "description", "bodyText"),
+  },
+  title: {
+    newName: "titleText",
+    message: formatMessage(component, "title", "titleText"),
+  },
+});
 
 const renames: Renames = {
-  NotAuthorized: {
-    description: {
-      newName: "bodyText",
-      message: formatMessage("description", "bodyText"),
-    },
-    title: {
-      newName: "titleText",
-      message: formatMessage("title", "titleText"),
-    },
-  },
+  NotAuthorized: getPropsRenames("NotAuthorized"),
+  UnauthorizedAccess: getPropsRenames("UnauthorizedAccess"),
 };
 
 module.exports = {

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsNotAuthorizedRenameToUnauthorizedAccess/component-groups-notAuthorized-rename-to-unauthorizedAccess.md
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsNotAuthorizedRenameToUnauthorizedAccess/component-groups-notAuthorized-rename-to-unauthorizedAccess.md
@@ -1,0 +1,18 @@
+### component-groups-notAuthorized-rename-to-unauthorizedAccess [(react-component-groups/#313)](https://github.com/patternfly/react-component-groups/pull/313)
+
+In react-component-groups, we've renamed NotAuthorized component to UnauthorizedAccess
+
+#### Examples
+
+In:
+
+```jsx
+%inputExample%
+```
+
+Out:
+
+```jsx
+%outputExample%
+```
+

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsNotAuthorizedRenameToUnauthorizedAccess/component-groups-notAuthorized-rename-to-unauthorizedAccess.test.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsNotAuthorizedRenameToUnauthorizedAccess/component-groups-notAuthorized-rename-to-unauthorizedAccess.test.ts
@@ -1,0 +1,61 @@
+const ruleTester = require("../../ruletester");
+import * as rule from "./component-groups-notAuthorized-rename-to-unauthorizedAccess";
+
+const errors = [
+  {
+    message: `NotAuthorized has been renamed to UnauthorizedAccess.`,
+    type: "JSXOpeningElement",
+  },
+];
+
+ruleTester.run(
+  "component-groups-notAuthorized-rename-to-unauthorizedAccess",
+  rule,
+  {
+    valid: [
+      // missing import
+      {
+        code: `<NotAuthorized />`,
+      },
+      // import from wrong package
+      {
+        code: `import { NotAuthorized } from '@patternfly/react-core'; <NotAuthorized />`,
+      },
+    ],
+    invalid: [
+      {
+        code: `import { NotAuthorized } from '@patternfly/react-component-groups'; <NotAuthorized />`,
+        output: `import { UnauthorizedAccess } from '@patternfly/react-component-groups'; <UnauthorizedAccess data-codemods />`,
+        errors,
+      },
+      // named import with alias
+      {
+        code: `import { NotAuthorized as NotAuth } from '@patternfly/react-component-groups'; <NotAuth />`,
+        output: `import { UnauthorizedAccess as NotAuth } from '@patternfly/react-component-groups'; <NotAuth />`,
+        errors,
+      },
+      // default imports
+      {
+        code: `import NotAuthorized from '@patternfly/react-component-groups/dist/cjs/NotAuthorized/index'; <NotAuthorized />`,
+        output: `import UnauthorizedAccess from '@patternfly/react-component-groups/dist/cjs/UnauthorizedAccess/index'; <UnauthorizedAccess data-codemods />`,
+        errors,
+      },
+      {
+        code: `import NotAuthorized from '@patternfly/react-component-groups/dist/esm/NotAuthorized/index'; <NotAuthorized />`,
+        output: `import UnauthorizedAccess from '@patternfly/react-component-groups/dist/esm/UnauthorizedAccess/index'; <UnauthorizedAccess data-codemods />`,
+        errors,
+      },
+      {
+        code: `import NotAuthorized from '@patternfly/react-component-groups/dist/dynamic/NotAuthorized'; <NotAuthorized />`,
+        output: `import UnauthorizedAccess from '@patternfly/react-component-groups/dist/dynamic/UnauthorizedAccess'; <UnauthorizedAccess data-codemods />`,
+        errors,
+      },
+      // default import with name not matching the component name
+      {
+        code: `import NotAuth from '@patternfly/react-component-groups/dist/dynamic/NotAuthorized'; <NotAuth />`,
+        output: `import NotAuth from '@patternfly/react-component-groups/dist/dynamic/UnauthorizedAccess'; <NotAuth />`,
+        errors,
+      },
+    ],
+  }
+);

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsNotAuthorizedRenameToUnauthorizedAccess/component-groups-notAuthorized-rename-to-unauthorizedAccess.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsNotAuthorizedRenameToUnauthorizedAccess/component-groups-notAuthorized-rename-to-unauthorizedAccess.ts
@@ -1,0 +1,12 @@
+import { renameComponent } from "../../helpers/renameComponent";
+
+// https://github.com/patternfly/react-component-groups/pull/313
+module.exports = {
+  meta: { fixable: "code" },
+  create: renameComponent(
+    {
+      NotAuthorized: "UnauthorizedAccess",
+    },
+    "@patternfly/react-component-groups"
+  ),
+};

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsNotAuthorizedRenameToUnauthorizedAccess/componentGroupsNotAuthorizedRenameToUnauthorizedAccessInput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsNotAuthorizedRenameToUnauthorizedAccess/componentGroupsNotAuthorizedRenameToUnauthorizedAccessInput.tsx
@@ -1,0 +1,4 @@
+import { NotAuthorized } from "@patternfly/react-component-groups";
+
+export const ComponentGroupsNotAuthorizedRenameToUnauthorizedAccessInput =
+  () => <NotAuthorized />;

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsNotAuthorizedRenameToUnauthorizedAccess/componentGroupsNotAuthorizedRenameToUnauthorizedAccessOutput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsNotAuthorizedRenameToUnauthorizedAccess/componentGroupsNotAuthorizedRenameToUnauthorizedAccessOutput.tsx
@@ -1,0 +1,4 @@
+import { UnauthorizedAccess } from "@patternfly/react-component-groups";
+
+export const ComponentGroupsNotAuthorizedRenameToUnauthorizedAccessInput =
+  () => <UnauthorizedAccess data-codemods />;

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/dataCodemodsCleanup/data-codemods-cleanup.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/dataCodemodsCleanup/data-codemods-cleanup.ts
@@ -3,6 +3,7 @@ import { ImportSpecifier, JSXOpeningElement } from "estree-jsx";
 import {
   checkMatchingJSXOpeningElement,
   getAttribute,
+  getDefaultImportsFromPackage,
   getFromPackage,
 } from "../../helpers";
 
@@ -17,8 +18,21 @@ module.exports = {
       context,
       "@patternfly/react-table"
     );
+    const { imports: componentGroupsImports } = getFromPackage(
+      context,
+      "@patternfly/react-component-groups"
+    );
+    const componentGroupsDefaultImports = getDefaultImportsFromPackage(
+      context,
+      "@patternfly/react-component-groups"
+    );
 
-    const imports = [...coreImports, ...tableImports];
+    const imports = [
+      ...coreImports,
+      ...tableImports,
+      ...componentGroupsImports,
+      ...componentGroupsDefaultImports,
+    ];
 
     const message =
       "This rule will remove data-codemods attributes and comments, which were introduced by our codemods in order to work correctly.";


### PR DESCRIPTION
Closes #769, #772, #773 

- Also changes the `renameComponent` helper to update node name when default import matches the component name, e.g.: `import InvalidObject from '@patternfly/react-component-groups/dist/cjs/InvalidObject/index'; <InvalidObject />` will update to `import MissingPage from '@patternfly/react-component-groups/dist/cjs/MissingPage/index'; <MissingPage data-codemods />`