### PR TITLE
fix: class name updater does not support absolute paths

### DIFF
--- a/packages/class-name-updater/src/classNameUpdate.ts
+++ b/packages/class-name-updater/src/classNameUpdate.ts
@@ -1,6 +1,6 @@
 import { sync } from "glob";
 import { readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { isAbsolute, join } from "path";
 import { isDir } from "./utils";
 import { printDiff } from "./printDiff";
 
@@ -31,7 +31,7 @@ export async function classNameUpdate(
   );
 
   includedFiles.forEach(async (file: string) => {
-    const filePath = join(process.cwd(), file);
+    const filePath = isAbsolute(file) ? file : join(process.cwd(), file);
     const isDirectory = await isDir(filePath);
     const isUnexpectedFile = !acceptedFileTypesRegex.test(filePath);
 


### PR DESCRIPTION
Closes #802

If the path given to class name updater is an absolute path, the tool raises an error. It adds the current working dir regardless of the path type.

This patch fixes this issue and only adds the current working dir if the file path is not absolute.