### PR TITLE
fix(formFiledGroupHeaderTitleTextObject): use renameInterface helper

### DIFF
--- a/packages/eslint-plugin-pf-codemods/src/rules/helpers/getFromPackage.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/helpers/getFromPackage.ts
@@ -81,7 +81,7 @@ export function getFromPackage(
     specifierNames.includes(specifier.imported.name)
   );
   const specifiedExports = exports.filter((specifier) =>
-    specifierNames.includes(specifier.exported.name)
+    specifierNames.includes(specifier.local.name)
   );
 
   return { imports: specifiedImports, exports: specifiedExports };

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectPropsRenameToMissingPageProps/component-groups-invalidObjectProps-rename-to-missingPageProps.test.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/componentGroupsInvalidObjectPropsRenameToMissingPageProps/component-groups-invalidObjectProps-rename-to-missingPageProps.test.ts
@@ -35,7 +35,7 @@ ruleTester.run(
         errors: [
           {
             message,
-            type: "ImportSpecifier",
+            type: "Identifier",
           },
           {
             message,
@@ -60,7 +60,7 @@ ruleTester.run(
         errors: [
           {
             message,
-            type: "ImportSpecifier",
+            type: "Identifier",
           },
         ],
       },
@@ -75,7 +75,7 @@ ruleTester.run(
           },
           {
             message,
-            type: "ImportSpecifier",
+            type: "Identifier",
           },
         ],
       },
@@ -89,7 +89,7 @@ ruleTester.run(
           },
           {
             message,
-            type: "ImportSpecifier",
+            type: "Identifier",
           },
         ],
       },
@@ -103,7 +103,7 @@ ruleTester.run(
           },
           {
             message,
-            type: "ImportSpecifier",
+            type: "Identifier",
           },
         ],
       },

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/formFiledGroupHeaderTitleTextObjectRenamed/formFiledGroupHeaderTitleTextObject-renamed.test.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/formFiledGroupHeaderTitleTextObjectRenamed/formFiledGroupHeaderTitleTextObject-renamed.test.ts
@@ -20,11 +20,11 @@ ruleTester.run("formFiledGroupHeaderTitleTextObject-renamed", rule, {
       errors: [
         {
           message: errorMessage,
-          type: "ImportSpecifier",
+          type: "Identifier",
         },
         {
           message: errorMessage,
-          type: "TSTypeReference",
+          type: "Identifier",
         },
       ],
     },
@@ -34,11 +34,11 @@ ruleTester.run("formFiledGroupHeaderTitleTextObject-renamed", rule, {
       errors: [
         {
           message: errorMessage,
-          type: "ImportSpecifier",
+          type: "Identifier",
         },
         {
           message: errorMessage,
-          type: "TSInterfaceHeritage",
+          type: "Identifier",
         },
       ],
     },
@@ -48,11 +48,11 @@ ruleTester.run("formFiledGroupHeaderTitleTextObject-renamed", rule, {
       errors: [
         {
           message: errorMessage,
-          type: "ImportSpecifier",
+          type: "Identifier",
         },
         {
           message: errorMessage,
-          type: "ExportSpecifier",
+          type: "Identifier",
         },
       ],
     },
@@ -62,7 +62,7 @@ ruleTester.run("formFiledGroupHeaderTitleTextObject-renamed", rule, {
       errors: [
         {
           message: errorMessage,
-          type: "ExportSpecifier",
+          type: "Identifier",
         },
       ],
     },

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/formFiledGroupHeaderTitleTextObjectRenamed/formFiledGroupHeaderTitleTextObject-renamed.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/formFiledGroupHeaderTitleTextObjectRenamed/formFiledGroupHeaderTitleTextObject-renamed.ts
@@ -1,87 +1,13 @@
-import { AST, Rule } from "eslint";
-import { ImportSpecifier, ExportSpecifier, Identifier, Node } from "estree-jsx";
-import { getFromPackage } from "../../helpers";
+import { renameInterface } from "../../helpers";
 
 // https://github.com/patternfly/patternfly-react/pull/10016
 module.exports = {
   meta: { fixable: "code" },
-  create: function (context: Rule.RuleContext) {
-    const { imports, exports } = getFromPackage(
-      context,
-      "@patternfly/react-core"
-    );
-
-    const previousName = "FormFiledGroupHeaderTitleTextObject";
-    const newName = "FormFieldGroupHeaderTitleTextObject";
-
-    const interfaceImport = imports.find(
-      (specifier) => specifier.imported.name === previousName
-    );
-
-    const interfaceExport = exports.find(
-      (specifier) => specifier.local.name === previousName
-    );
-
-    if (!interfaceImport && !interfaceExport) {
-      return {};
-    }
-
-    const hasAlias = (specifier: ImportSpecifier) =>
-      specifier.local.name !== specifier.imported.name;
-
-    const reportMessage =
-      "There was a typo in FormFiledGroupHeaderTitleTextObject interface. It was renamed to the intended FormFieldGroupHeaderTitleTextObject.";
-
-    const callContextReport = (node: Node, nodeToReplace: Node | AST.Token) => {
-      context.report({
-        node,
-        message: reportMessage,
-        fix(fixer) {
-          return fixer.replaceText(nodeToReplace, newName);
-        },
-      });
-    };
-
-    return {
-      ImportSpecifier(node: ImportSpecifier) {
-        if (
-          interfaceImport &&
-          node.imported.name === interfaceImport.imported.name
-        ) {
-          callContextReport(node, node.imported);
-        }
-      },
-      ExportSpecifier(node: ExportSpecifier) {
-        if (interfaceExport && node.local.name === interfaceExport.local.name) {
-          callContextReport(node, node.local);
-        }
-
-        if (
-          interfaceImport &&
-          !hasAlias(interfaceImport) &&
-          node.local.name === previousName
-        ) {
-          callContextReport(node, node.local);
-        }
-      },
-      TSTypeReference(node: { typeName: Identifier }) {
-        if (
-          interfaceImport &&
-          !hasAlias(interfaceImport) &&
-          node.typeName.name === previousName
-        ) {
-          callContextReport(node as unknown as Node, node.typeName);
-        }
-      },
-      TSInterfaceHeritage(node: { expression: Identifier }) {
-        if (
-          interfaceImport &&
-          !hasAlias(interfaceImport) &&
-          node.expression.name === previousName
-        ) {
-          callContextReport(node as unknown as Node, node.expression);
-        }
-      },
-    };
-  },
+  create: renameInterface({
+    FormFiledGroupHeaderTitleTextObject: {
+      newName: "FormFieldGroupHeaderTitleTextObject",
+      message:
+        "There was a typo in FormFiledGroupHeaderTitleTextObject interface. It was renamed to the intended FormFieldGroupHeaderTitleTextObject.",
+    },
+  }),
 };


### PR DESCRIPTION
Closes #622

- refactors and fixes the `renameInterface` helper to support custom messages and check `ExportSpecifier` too
- modifies FormFiledGroupHeaderTitleTextObject rule to use the helper (which uses the correct TS node types, unlike the rule before)