### PR TITLE
fixes to hasAnimations codemod

### DIFF
--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/enableAnimations/enable-animations.md
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/enableAnimations/enable-animations.md
@@ -2,13 +2,17 @@
 
 This rule adds the `hasAnimations` prop to PatternFly components that support animations. This is an optional enhancement that enables smoother transitions and animations in your UI components.
 
+**⚠️ Important:** Enabling animations may change the DOM structure of some components. This could affect CSS selectors, testing queries, or other code that relies on the specific DOM structure. Review your code after enabling animations to ensure compatibility.
+
 The following components will have `hasAnimations` added:
 - AlertGroup
-- DualListSelector  
+- DualListSelector (only when `isTree` prop has a truthy value)
 - FormFieldGroupExpandable
-- SearchInput
+- SearchInputExpandable
 - TreeView
 - Table (from @patternfly/react-table)
+
+**Note:** For DualListSelector, the `hasAnimations` prop will only be added when the `isTree` prop is present and has a truthy value (e.g., `isTree`, `isTree={true}`, `isTree="yes"`, `isTree={1}`). It will not be added when `isTree` is falsy (e.g., `isTree={false}`, `isTree=""`, `isTree={0}`) or when the `isTree` prop is not present at all.
 
 This rule can only run using the `--only enable-animations` option.
 
@@ -17,33 +21,11 @@ This rule can only run using the `--only enable-animations` option.
 In:
 
 ```jsx
-import { AlertGroup, TreeView } from '@patternfly/react-core';
-import { Table } from '@patternfly/react-table';
-
-export const Example = () => (
-  <>
-    <AlertGroup isLiveRegion>
-      {/* alerts */}
-    </AlertGroup>
-    <TreeView />
-    <Table />
-  </>
-);
+%inputExample%
 ```
 
 Out:
 
 ```jsx
-import { AlertGroup, TreeView } from '@patternfly/react-core';
-import { Table } from '@patternfly/react-table';
-
-export const Example = () => (
-  <>
-    <AlertGroup hasAnimations isLiveRegion>
-      {/* alerts */}
-    </AlertGroup>
-    <TreeView hasAnimations />
-    <Table hasAnimations />
-  </>
-);
+%outputExample%
 ``` 

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/enableAnimations/enable-animations.test.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/enableAnimations/enable-animations.test.ts
@@ -1,152 +1,128 @@
 const ruleTester = require("../../ruletester");
 import * as rule from "./enable-animations";
 
+const valid = [
+  // Components not in target list should be ignored
+  "<AlertGroup />",
+  "import { AlertGroup } from '@patternfly/react-core'; <AlertGroup hasAnimations />",
+  "import { AlertGroup } from '@patternfly/react-core'; <AlertGroup hasAnimations={true} />",
+  "import { Table } from '@patternfly/react-table'; <Table hasAnimations />",
+  // Component not in target components
+  "import { Button } from '@patternfly/react-core'; <Button />",
+  // DualListSelector without isTree should not get hasAnimations
+  "import { DualListSelector } from '@patternfly/react-core'; <DualListSelector />",
+  // DualListSelector with isTree={false} should not get hasAnimations
+  "import { DualListSelector } from '@patternfly/react-core'; <DualListSelector isTree={false} />",
+  // DualListSelector with isTree and hasAnimations already present
+  "import { DualListSelector } from '@patternfly/react-core'; <DualListSelector isTree hasAnimations />",
+];
+
+const invalid = [
+  {
+    code: "import { AlertGroup } from '@patternfly/react-core'; <AlertGroup />",
+    output: "import { AlertGroup } from '@patternfly/react-core'; <AlertGroup hasAnimations />",
+    errors: [
+      { 
+        message: "Consider adding hasAnimations prop to enable component animations.",
+        type: "JSXOpeningElement"
+      }
+    ]
+  },
+  {
+    code: "import { DualListSelector } from '@patternfly/react-core'; <DualListSelector isTree />",
+    output: "import { DualListSelector } from '@patternfly/react-core'; <DualListSelector isTree hasAnimations />",
+    errors: [
+      { 
+        message: "Consider adding hasAnimations prop to enable component animations.",
+        type: "JSXOpeningElement"
+      }
+    ]
+  },
+  {
+    code: "import { DualListSelector } from '@patternfly/react-core'; <DualListSelector isTree={true} />",
+    output: "import { DualListSelector } from '@patternfly/react-core'; <DualListSelector isTree={true} hasAnimations />",
+    errors: [
+      { 
+        message: "Consider adding hasAnimations prop to enable component animations.",
+        type: "JSXOpeningElement"
+      }
+    ]
+  },
+  {
+    code: "import { TreeView } from '@patternfly/react-core'; <TreeView />",
+    output: "import { TreeView } from '@patternfly/react-core'; <TreeView hasAnimations />",
+    errors: [
+      { 
+        message: "Consider adding hasAnimations prop to enable component animations.",
+        type: "JSXOpeningElement"
+      }
+    ]
+  },
+  {
+    code: "import { SearchInputExpandable } from '@patternfly/react-core'; <SearchInputExpandable />",
+    output: "import { SearchInputExpandable } from '@patternfly/react-core'; <SearchInputExpandable hasAnimations />",
+    errors: [
+      { 
+        message: "Consider adding hasAnimations prop to enable component animations.",
+        type: "JSXOpeningElement"
+      }
+    ]
+  },
+  {
+    code: "import { FormFieldGroupExpandable } from '@patternfly/react-core'; <FormFieldGroupExpandable />",
+    output: "import { FormFieldGroupExpandable } from '@patternfly/react-core'; <FormFieldGroupExpandable hasAnimations />",
+    errors: [
+      { 
+        message: "Consider adding hasAnimations prop to enable component animations.",
+        type: "JSXOpeningElement"
+      }
+    ]
+  },
+  {
+    code: "import { Table } from '@patternfly/react-table'; <Table />",
+    output: "import { Table } from '@patternfly/react-table'; <Table hasAnimations />",
+    errors: [
+      { 
+        message: "Consider adding hasAnimations prop to enable component animations.",
+        type: "JSXOpeningElement"
+      }
+    ]
+  },
+  {
+    code: `import { AlertGroup, TreeView } from '@patternfly/react-core'; 
+      <>
+        <AlertGroup />
+        <TreeView />
+      </>`,
+    output: `import { AlertGroup, TreeView } from '@patternfly/react-core'; 
+      <>
+        <AlertGroup hasAnimations />
+        <TreeView hasAnimations />
+      </>`,
+    errors: [
+      { 
+        message: "Consider adding hasAnimations prop to enable component animations.",
+        type: "JSXOpeningElement"
+      },
+      { 
+        message: "Consider adding hasAnimations prop to enable component animations.",
+        type: "JSXOpeningElement"
+      }
+    ]
+  },
+  {
+    code: "import { AlertGroup } from '@patternfly/react-core'; <AlertGroup isLiveRegion />",
+    output: "import { AlertGroup } from '@patternfly/react-core'; <AlertGroup isLiveRegion hasAnimations />",
+    errors: [
+      { 
+        message: "Consider adding hasAnimations prop to enable component animations.",
+        type: "JSXOpeningElement"
+      }
+    ]
+  }
+];
+
 ruleTester.run("enable-animations", rule, {
-  valid: [
-    // No imports, should not trigger
-    {
-      code: `<AlertGroup />`,
-    },
-    // Already has hasAnimations prop
-    {
-      code: `import { AlertGroup } from '@patternfly/react-core'; <AlertGroup hasAnimations />`,
-    },
-    // Already has hasAnimations with value
-    {
-      code: `import { AlertGroup } from '@patternfly/react-core'; <AlertGroup hasAnimations={true} />`,
-    },
-    // Table already has hasAnimations
-    {
-      code: `import { Table } from '@patternfly/react-table'; <Table hasAnimations />`,
-    },
-    // Non-target component should not be affected
-    {
-      code: `import { Button } from '@patternfly/react-core'; <Button />`,
-    },
-  ],
-  invalid: [
-    // AlertGroup without hasAnimations
-    {
-      code: `import { AlertGroup } from '@patternfly/react-core'; <AlertGroup />`,
-      output: `import { AlertGroup } from '@patternfly/react-core'; <AlertGroup hasAnimations />`,
-      errors: [
-        {
-          message: "Consider adding hasAnimations prop to enable component animations.",
-          type: "JSXOpeningElement",
-        },
-      ],
-    },
-    // DualListSelector without hasAnimations
-    {
-      code: `import { DualListSelector } from '@patternfly/react-core'; <DualListSelector />`,
-      output: `import { DualListSelector } from '@patternfly/react-core'; <DualListSelector hasAnimations />`,
-      errors: [
-        {
-          message: "Consider adding hasAnimations prop to enable component animations.",
-          type: "JSXOpeningElement",
-        },
-      ],
-    },
-    // TreeView without hasAnimations
-    {
-      code: `import { TreeView } from '@patternfly/react-core'; <TreeView />`,
-      output: `import { TreeView } from '@patternfly/react-core'; <TreeView hasAnimations />`,
-      errors: [
-        {
-          message: "Consider adding hasAnimations prop to enable component animations.",
-          type: "JSXOpeningElement",
-        },
-      ],
-    },
-    // SearchInput without hasAnimations
-    {
-      code: `import { SearchInput } from '@patternfly/react-core'; <SearchInput />`,
-      output: `import { SearchInput } from '@patternfly/react-core'; <SearchInput hasAnimations />`,
-      errors: [
-        {
-          message: "Consider adding hasAnimations prop to enable component animations.",
-          type: "JSXOpeningElement",
-        },
-      ],
-    },
-    // FormFieldGroupExpandable without hasAnimations
-    {
-      code: `import { FormFieldGroupExpandable } from '@patternfly/react-core'; <FormFieldGroupExpandable />`,
-      output: `import { FormFieldGroupExpandable } from '@patternfly/react-core'; <FormFieldGroupExpandable hasAnimations />`,
-      errors: [
-        {
-          message: "Consider adding hasAnimations prop to enable component animations.",
-          type: "JSXOpeningElement",
-        },
-      ],
-    },
-    // Table from react-table without hasAnimations
-    {
-      code: `import { Table } from '@patternfly/react-table'; <Table />`,
-      output: `import { Table } from '@patternfly/react-table'; <Table hasAnimations />`,
-      errors: [
-        {
-          message: "Consider adding hasAnimations prop to enable component animations.",
-          type: "JSXOpeningElement",
-        },
-      ],
-    },
-    // Multiple components in one file
-    {
-      code: `import { AlertGroup, TreeView } from '@patternfly/react-core'; 
-        <>
-          <AlertGroup />
-          <TreeView />
-        </>`,
-      output: `import { AlertGroup, TreeView } from '@patternfly/react-core'; 
-        <>
-          <AlertGroup hasAnimations />
-          <TreeView hasAnimations />
-        </>`,
-      errors: [
-        {
-          message: "Consider adding hasAnimations prop to enable component animations.",
-          type: "JSXOpeningElement",
-        },
-        {
-          message: "Consider adding hasAnimations prop to enable component animations.",
-          type: "JSXOpeningElement",
-        },
-      ],
-    },
-    // Component with existing props
-    {
-      code: `import { AlertGroup } from '@patternfly/react-core'; <AlertGroup isLiveRegion />`,
-      output: `import { AlertGroup } from '@patternfly/react-core'; <AlertGroup hasAnimations isLiveRegion />`,
-      errors: [
-        {
-          message: "Consider adding hasAnimations prop to enable component animations.",
-          type: "JSXOpeningElement",
-        },
-      ],
-    },
-    // Self-closing and regular tags
-    {
-      code: `import { DualListSelector } from '@patternfly/react-core'; 
-        <>
-          <DualListSelector />
-          <DualListSelector></DualListSelector>
-        </>`,
-      output: `import { DualListSelector } from '@patternfly/react-core'; 
-        <>
-          <DualListSelector hasAnimations />
-          <DualListSelector hasAnimations></DualListSelector>
-        </>`,
-      errors: [
-        {
-          message: "Consider adding hasAnimations prop to enable component animations.",
-          type: "JSXOpeningElement",
-        },
-        {
-          message: "Consider adding hasAnimations prop to enable component animations.",
-          type: "JSXOpeningElement",
-        },
-      ],
-    },
-  ],
+  valid: valid,
+  invalid: invalid,
 }); 

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/enableAnimations/enableAnimationsInput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/enableAnimations/enableAnimationsInput.tsx
@@ -1,4 +1,4 @@
-import { AlertGroup, TreeView, DualListSelector, SearchInput, FormFieldGroupExpandable } from "@patternfly/react-core";
+import { AlertGroup, TreeView, DualListSelector, SearchInputExpandable, FormFieldGroupExpandable } from "@patternfly/react-core";
 import { Table } from "@patternfly/react-table";
 
 export const EnableAnimationsInput = () => (
@@ -8,7 +8,10 @@ export const EnableAnimationsInput = () => (
     </AlertGroup>
     <TreeView />
     <DualListSelector />
-    <SearchInput />
+    <DualListSelector isTree />
+    <DualListSelector isTree={true} />
+    <DualListSelector isTree={false} />
+    <SearchInputExpandable />
     <FormFieldGroupExpandable />
     <Table />
   </>

--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/enableAnimations/enableAnimationsOutput.tsx
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/enableAnimations/enableAnimationsOutput.tsx
@@ -1,4 +1,4 @@
-import { AlertGroup, TreeView, DualListSelector, SearchInput, FormFieldGroupExpandable } from "@patternfly/react-core";
+import { AlertGroup, TreeView, DualListSelector, SearchInputExpandable, FormFieldGroupExpandable } from "@patternfly/react-core";
 import { Table } from "@patternfly/react-table";
 
 export const EnableAnimationsOutput = () => (
@@ -7,8 +7,11 @@ export const EnableAnimationsOutput = () => (
       {/* alerts */}
     </AlertGroup>
     <TreeView hasAnimations />
-    <DualListSelector hasAnimations />
-    <SearchInput hasAnimations />
+    <DualListSelector />
+    <DualListSelector isTree hasAnimations />
+    <DualListSelector isTree={true} hasAnimations />
+    <DualListSelector isTree={false} />
+    <SearchInputExpandable hasAnimations />
     <FormFieldGroupExpandable hasAnimations />
     <Table hasAnimations />
   </>


### PR DESCRIPTION
fixes some notes from post-merge reviews on https://github.com/patternfly/pf-codemods/pull/843 as well as an issue that came up where `hasAnimations` is supposed to go on SearchInputExpandable instead of SearchInput.