### PR TITLE
fix: split table hasAnimations fix with cli option

### DIFF
--- a/packages/eslint-plugin-pf-codemods/src/rules/v6/enableAnimations/enable-animations.ts
+++ b/packages/eslint-plugin-pf-codemods/src/rules/v6/enableAnimations/enable-animations.ts
@@ -7,6 +7,12 @@ import { getAttribute, getAttributeValue } from "../../helpers/JSXAttributes";
 module.exports = {
   meta: { fixable: "code" },
   create: function (context: Rule.RuleContext) {
+    // Get options from context (set by CLI)
+    const includeTable =
+      (context.settings && context.settings.enableAnimationsIncludeTable) ||
+      (context.options && context.options[0] && context.options[0].includeTable) ||
+      false;
+
     // Get imports from both react-core and react-table packages
     const { imports: coreImports } = getFromPackage(
       context,
@@ -34,9 +40,12 @@ module.exports = {
       targetComponents.includes(specifier.imported.name)
     );
 
-    const targetTableImports = tableImports.filter((specifier) =>
-      tableComponents.includes(specifier.imported.name)
-    );
+    // Only include Table if option is set
+    const targetTableImports = includeTable
+      ? tableImports.filter((specifier) =>
+          tableComponents.includes(specifier.imported.name)
+        )
+      : [];
 
     const allTargetImports = [...targetCoreImports, ...targetTableImports];
 

--- a/packages/pf-codemods/index.js
+++ b/packages/pf-codemods/index.js
@@ -73,7 +73,13 @@ async function getRulesToRemove(options) {
   const pfVersions = ["v6", "v5", "v4"];
   let selectedVersion = pfVersions.find((version) => options[version]);
 
-  if (!selectedVersion) {
+  // If only enable-animations is being run, skip the PatternFly version prompt and default to v6 logic
+  let skipVersionPrompt = false;
+  if (options.only && options.only.split(",").length === 1 && options.only.includes("enable-animations")) {
+    skipVersionPrompt = true;
+  }
+
+  if (!selectedVersion && !skipVersionPrompt) {
     const inquirer = await import("inquirer");
     const answer = await inquirer.default.prompt([
       {
@@ -87,8 +93,9 @@ async function getRulesToRemove(options) {
         ],
       },
     ]);
-
     selectedVersion = answer.version;
+  } else if (skipVersionPrompt) {
+    return [];
   }
 
   return pfVersions.flatMap((version) =>
@@ -98,6 +105,33 @@ async function getRulesToRemove(options) {
 
 async function runCodemods(path, otherPaths, options) {
   const prefix = "@patternfly/pf-codemods/";
+
+  // Determine if enable-animations is being run
+  let enableAnimationsRule = false;
+  if (options.only) {
+    enableAnimationsRule = options.only.split(",").includes("enable-animations");
+  } else {
+    enableAnimationsRule = Object.keys(configs.recommended.rules).includes(prefix + "enable-animations");
+  }
+
+  let enableAnimationsIncludeTable = false;
+  if (enableAnimationsRule) {
+    const inquirer = await import("inquirer");
+    const answer = await inquirer.default.prompt([
+      {
+        type: "list",
+        name: "includeTable",
+        message:
+          "This will update several React Core components. Which components would you like to update? (Note: Some users have reported issues with enabling animations on Table.)",
+        choices: [
+          { name: "Just React Core components", value: false },
+          { name: "React Core and Table components", value: true },
+        ],
+        default: 0,
+      },
+    ]);
+    enableAnimationsIncludeTable = answer.includeTable;
+  }
 
   if (options.only) {
     // Set rules to error like eslint likes
@@ -159,6 +193,9 @@ async function runCodemods(path, otherPaths, options) {
           {},
           ...rulesArr.filter(filterFunc).map((r) => r.rule)
         ),
+        settings: enableAnimationsRule ? {
+          enableAnimationsIncludeTable: enableAnimationsIncludeTable
+        } : {}
       },
     });
   });


### PR DESCRIPTION
if a user passes the option to only run enable-animations, it will skip the version check and ask them "This will update several React Core components. Which components would you like to update? (Note: Some users have reported issues with enabling animations on Table.)"

i thought about adding "If an issue happens, it's Eric's fault", but didn't.

with choices: 
"Just React Core components"
or
"React Core and Table components"